### PR TITLE
issue 223: Fix episode edit when categories are disabled

### DIFF
--- a/PodcastGenerator/admin/episodes_edit.php
+++ b/PodcastGenerator/admin/episodes_edit.php
@@ -47,8 +47,13 @@ if (isset($_GET['edit'])) {
         }
     }
 
-    // Check if the user selected too much episodes
-    if (sizeof($_POST['category']) > 3) {
+    // If no categories were selected, add the 'uncategorized'
+    // category.  Otherwise, ensure that no more than three categories
+    // were actually selected.
+    if (sizeof($_POST['category']) == 0) {
+        $_POST['category'] = array();
+        array_push($_POST['category'], 'uncategorized');
+    } else if (sizeof($_POST['category']) > 3) {
         $error = _('Too many categories selected (max: 3)');
         goto error;
     }
@@ -161,7 +166,7 @@ $episode = simplexml_load_file('../' . $config['upload_dir'] . pathinfo('../' . 
                         <input type="text" id="shortdesc" name="shortdesc" class="form-control" value="<?php echo htmlspecialchars($episode->episode->shortdescPG); ?>" maxlength="255" oninput="shortDescCheck()" required>
                         <i id="shortdesc_counter">255<?php echo _(' characters remaining'); ?></i>
                     </div>
-                    <div class="form-group">
+                    <div class="form-group" style="display: <?php echo ($config['categoriesenabled'] != 'yes') ? 'none' : 'block'; ?>">
                         <?php echo _('Category'); ?>:<br>
                         <small><?php echo _('You can select up to 3 categories'); ?></small><br>
                         <select name="category[ ]" multiple>

--- a/PodcastGenerator/admin/episodes_upload.php
+++ b/PodcastGenerator/admin/episodes_upload.php
@@ -29,14 +29,13 @@ if (isset($_GET['upload'])) {
         }
     }
 
-    // Check if categories are even enabled and then do uncategorized
-    if (strtolower($config['categoriesenabled']) != 'yes') {
+    // If no categories were selected, add the 'uncategorized'
+    // category.  Otherwise, ensure that no more than three categories
+    // were actually selected.
+    if (sizeof($_POST['category']) == 0) {
         $_POST['category'] = array();
         array_push($_POST['category'], 'uncategorized');
-    }
-
-    // Check if the user selected too much episodes
-    if (sizeof($_POST['category']) > 3) {
+    } else if (sizeof($_POST['category']) > 3) {
         $error = _('Too many categories selected (max: 3)');
         goto error;
     }
@@ -218,24 +217,18 @@ if (isset($_GET['upload'])) {
                         <input type="text" id="shortdesc" name="shortdesc" class="form-control" maxlength="255" oninput="shortDescCheck()" required>
                         <i id="shortdesc_counter">255 <?php echo _('characters remaining'); ?></i>
                     </div>
-                    <?php
-                    if (strtolower($config['categoriesenabled']) == 'yes') {
-                    ?>
-                        <div class="form-group">
-                            <?php echo _('Category'); ?>:<br>
-                            <small><?php echo _('You can select up to 3 categories'); ?></small><br>
-                            <select name="category[ ]" multiple>
-                                <?php
-                                $categories = simplexml_load_file('../categories.xml');
-                                foreach ($categories as $item) {
-                                    echo '<option value="' . htmlspecialchars($item->id) . '">' . htmlspecialchars($item->description) . '</option>';
-                                }
-                                ?>
-                            </select>
-                        </div>
-                    <?php
-                    }
-                    ?>
+                    <div class="form-group" style="display: <?php echo ($config['categoriesenabled'] != 'yes') ? 'none' : 'block'; ?>">
+                        <?php echo _('Category'); ?>:<br>
+                        <small><?php echo _('You can select up to 3 categories'); ?></small><br>
+                        <select name="category[ ]" multiple>
+                            <?php
+                            $categories = simplexml_load_file('../categories.xml');
+                            foreach ($categories as $item) {
+                                echo '<option value="' . htmlspecialchars($item->id) . '">' . htmlspecialchars($item->description) . '</option>';
+                            }
+                            ?>
+                        </select>
+                    </div>
                     <div class="form-group">
                         <?php echo _('Publication Date'); ?>:<br>
                         <small><?php echo _('If you select a date in the future, it will be published then'); ?></small><br>


### PR DESCRIPTION
This is a two-part fix, made to both the Upload and Edit forms.

First, if categories aren't enabled at all by the configuration, we
hide that section of the edit form.  There's no use showing a category
selection widget that doesn't get used.

Secondly, the processing logic of both forms will, when no categories
have been selected in the form, insert the singular 'uncategorized'
category -- just like the episode upload logic does.

NOTE: This fix requires my prior change which makes the category
selection optional.

<!-- Please check all checkboxes by putting a 'x' into it. Example: [x] -->

* [X] I am the author of this code or the code is public domain
* [X] I release this code into the public domain
