### PR TITLE
Fixing #235 | #216 | #185 | #304

### DIFF
--- a/PodcastGenerator/admin/episodes_edit.php
+++ b/PodcastGenerator/admin/episodes_edit.php
@@ -103,7 +103,7 @@ if (sizeof($_POST) > 0) {
     $episodefeed = '<?xml version="1.0" encoding="utf-8"?>
 <PodcastGenerator>
 	<episode>
-	    <titlePG><![CDATA[' . htmlspecialchars($_POST['title']) . ']]></titlePG>
+	    <titlePG><![CDATA[' . htmlspecialchars($_POST['title'], ENT_NOQUOTES) . ']]></titlePG>
 	    <shortdescPG><![CDATA[' . htmlspecialchars($_POST['shortdesc']) . ']]></shortdescPG>
 	    <longdescPG><![CDATA[' . htmlspecialchars($long_desc) . ']]></longdescPG>
 	    <imgPG></imgPG>

--- a/PodcastGenerator/admin/episodes_edit.php
+++ b/PodcastGenerator/admin/episodes_edit.php
@@ -221,6 +221,23 @@ $episode = simplexml_load_file('../' . $config['upload_dir'] . pathinfo('../' . 
                         <input type="text" class="form-control" name="authorname" placeholder="Author Name" value="<?php echo htmlspecialchars($episode->episode->authorPG->namePG); ?>"><br>
                         <input type="email" class="form-control" name="authoremail" placeholder="Author E-Mail" value="<?php echo htmlspecialchars($episode->episode->authorPG->emailPG); ?>"><br>
                     </div>
+                    <div class="form-group">
+                        <?php echo _('Episode Number'); ?>:<br>
+                        <input type="text" class="form-control" name="episodenumber" placeholder="<?php echo _('Episode Number'); ?>" value="<?php echo htmlspecialchars($episode->episode->episodePG); ?>">
+                        <?php echo _('Season Number'); ?>:<br>
+                        <input type="text" class="form-control" name="seasonnumber" placeholder="<?php echo _('Season Number'); ?>" value="<?php echo htmlspecialchars($episode->episode->seasonPG); ?>">
+                        <?php echo _('Episode Type'); ?>:<br>
+                        <select name="episodetype">
+                            <option value="full" selected>Normal Episode</option>
+                            <option value="trailer">Trailer</option>
+                            <option value="bonus">Bonus</option>
+                        </select><br>
+                        <?php echo _('Episode Status'); ?>:<br>
+                        <select name="episodeblock">
+                            <option value="No" selected>Avaliable</option>
+                            <option value="Yes">Blocked</option>
+                        </select><br>
+                    </div>
                     <input type="submit" class="btn btn-success btn-lg" value="<?php echo _('Save Changes'); ?>">
                 </div>
             </div>

--- a/PodcastGenerator/admin/episodes_ftp_feature.php
+++ b/PodcastGenerator/admin/episodes_ftp_feature.php
@@ -85,7 +85,7 @@ if (isset($_GET['start'])) {
         $episodefeed = '<?xml version="1.0" encoding="utf-8"?>
 <PodcastGenerator>
 	<episode>
-	    <titlePG><![CDATA[' . htmlspecialchars($title) . ']]></titlePG>
+	    <titlePG><![CDATA[' . htmlspecialchars($title, ENT_NOQUOTES) . ']]></titlePG>
 	    <shortdescPG><![CDATA[' . htmlspecialchars($comment) . ']]></shortdescPG>
 	    <longdescPG><![CDATA[' . htmlspecialchars($comment) . ']]></longdescPG>
 	    <imgPG></imgPG>

--- a/PodcastGenerator/admin/episodes_upload.php
+++ b/PodcastGenerator/admin/episodes_upload.php
@@ -32,6 +32,7 @@ if (sizeof($_POST) > 0) {
     // If no categories were selected, add the 'uncategorized'
     // category.  Otherwise, ensure that no more than three categories
     // were actually selected.
+
     if (sizeof((array)$_POST['category']) == 0) {
         $_POST['category'] = array();
         array_push($_POST['category'], 'uncategorized');
@@ -260,6 +261,23 @@ if (sizeof($_POST) > 0) {
                         <?php echo _('Author'); ?>*:<br>
                         <input type="text" class="form-control" name="authorname" placeholder="<?php echo _('Author Name'); ?>" value="<?php echo htmlspecialchars($config["author_name"]); ?>"><br>
                         <input type="email" class="form-control" name="authoremail" placeholder="<?php echo _('Author E-Mail'); ?>" value="<?php echo htmlspecialchars($config["author_email"]); ?>"><br>
+                    </div>
+                    <div class="form-group">
+                        <?php echo _('Episode Number'); ?>:<br>
+                        <input type="text" class="form-control" name="episodenumber" placeholder="<?php echo _('Episode Number'); ?>">
+                        <?php echo _('Season Number'); ?>:<br>
+                        <input type="text" class="form-control" name="seasonnumber" placeholder="<?php echo _('Season Number'); ?>">
+                        <?php echo _('Episode Type'); ?>:<br>
+                        <select name="episodetype">
+                            <option value="full" selected>Normal Episode</option>
+                            <option value="trailer">Trailer</option>
+                            <option value="bonus">Bonus</option>
+                        </select><br>
+                        <?php echo _('Episode Status'); ?>:<br>
+                        <select name="episodeblock">
+                            <option value="No" selected>Avaliable</option>
+                            <option value="Yes">Blocked</option>
+                        </select><br>
                     </div>
                     <input type="submit" class="btn btn-success btn-lg" value="<?php echo _('Upload episode'); ?>">
                 </div>

--- a/PodcastGenerator/admin/episodes_upload.php
+++ b/PodcastGenerator/admin/episodes_upload.php
@@ -139,7 +139,7 @@ if (sizeof($_POST) > 0) {
     $episodefeed = '<?xml version="1.0" encoding="utf-8"?>
 <PodcastGenerator>
 	<episode>
-	    <titlePG><![CDATA[' . htmlspecialchars($_POST['title']) . ']]></titlePG>
+	    <titlePG><![CDATA[' . htmlspecialchars($_POST['title'], ENT_NOQUOTES) . ']]></titlePG>
 	    <shortdescPG><![CDATA[' . htmlspecialchars($_POST['shortdesc']) . ']]></shortdescPG>
 	    <longdescPG><![CDATA[' . htmlspecialchars($_POST['longdesc']) . ']]></longdescPG>
 	    <imgPG></imgPG>

--- a/PodcastGenerator/core/feed_generator.php
+++ b/PodcastGenerator/core/feed_generator.php
@@ -12,9 +12,10 @@ function generateRSS()
     // Make variables available in this scope
     global $config, $version;
     // Create path if it doesn't exist
-    if (!is_dir($config['absoluteurl'] . $config['feed_dir'])) {
-        mkdir($config['absoluteurl'] . $config['feed_dir']);
-    }
+    $feed_dir = (isset($config['feed_dir'])) ? $config['feed_dir'] :  '';
+    if (!is_dir($config['absoluteurl'] . $feed_dir) ){
+        mkdir($config['absoluteurl'] . $feed_dir);
+
     // Set the feed header with relevant podcast informations
     $feedhead = '<?xml version="1.0" encoding="' . $config['feed_encoding'] . '"?>
     <!-- generator="Podcast Generator ' . $version . '" -->
@@ -131,6 +132,10 @@ function generateRSS()
         $item = '
         <item>' . "\n";
         $item .= $indent . '<title>' . $file->episode->titlePG . '</title>' . $linebreak;
+        $item .= $indent . '<itunes:episode>' . $file->episode->episodePG . '</itunes:episode>' . $linebreak;
+        $item .= $indent . '<itunes:episodeType>' . $file->episode->typePG . '</itunes:episodeType>' . $linebreak;
+			  $item .= $indent . '<itunes:block><![CDATA[' . $file->episode->blockPG . ']]></itunes:block>' . $linebreak;
+        $item .= $indent . '<itunes:season>' . $file->episode->seasonPG . '</itunes:season>' . $linebreak;
         $item .= $indent . '<itunes:subtitle>' . $file->episode->shortdescPG . '</itunes:subtitle>' . $linebreak;
         $item .= $indent . '<description>' . $file->episode->shortdescPG . '</description>' . $linebreak;
         if ($file->episode->longdescPG == "<![CDATA[]]>") {
@@ -169,5 +174,5 @@ function generateRSS()
     }
     // Append footer
     $xml .= $feedfooter;
-    return file_put_contents($config['absoluteurl'] . $config['feed_dir'] .  'feed.xml', $xml);
+    return file_put_contents($config['absoluteurl'] . $feed_dir .  'feed.xml', $xml);
 }

--- a/PodcastGenerator/index.php
+++ b/PodcastGenerator/index.php
@@ -10,8 +10,8 @@
 session_start();
 require 'core/include.php';
 // Check if a password is set
-if ($config['podcastPassword'] != "") {
-    if (!isset($_SESSION['password'])) {
+if(!empty($config['podcastPassword]'])) {
+    if(!isset($_SESSION['password'])) {
         header('Location: auth.php');
         die(_('Authentication required'));
     }


### PR DESCRIPTION
<!-- Please check all checkboxes by putting a 'x' into it. Example: [x] -->

* [x] I am the author of this code or the code is public domain
* [x] I release this code into the public domain

These changes are made to the feed_generator.php to ensure that variables are set.  I think there might be something wrong with the way that the config is being parsed as values left blank are neglected from the runtime `$config` array, however, some in-place validation seems to be enough. 

Additionally there where some errors with the session already being started and thus the second file modified are `index.php` to ensure that the server is first checking for the existence of the variable. 