### PR TITLE
Fixing #304

### DIFF
--- a/PodcastGenerator/admin/episodes_edit.php
+++ b/PodcastGenerator/admin/episodes_edit.php
@@ -103,7 +103,7 @@ if (sizeof($_POST) > 0) {
     $episodefeed = '<?xml version="1.0" encoding="utf-8"?>
 <PodcastGenerator>
 	<episode>
-	    <titlePG><![CDATA[' . htmlspecialchars($_POST['title']) . ']]></titlePG>
+	    <titlePG><![CDATA[' . htmlspecialchars($_POST['title'], ENT_NOQUOTES) . ']]></titlePG>
 	    <shortdescPG><![CDATA[' . htmlspecialchars($_POST['shortdesc']) . ']]></shortdescPG>
 	    <longdescPG><![CDATA[' . htmlspecialchars($long_desc) . ']]></longdescPG>
 	    <imgPG></imgPG>

--- a/PodcastGenerator/admin/episodes_ftp_feature.php
+++ b/PodcastGenerator/admin/episodes_ftp_feature.php
@@ -85,7 +85,7 @@ if (isset($_GET['start'])) {
         $episodefeed = '<?xml version="1.0" encoding="utf-8"?>
 <PodcastGenerator>
 	<episode>
-	    <titlePG><![CDATA[' . htmlspecialchars($title) . ']]></titlePG>
+	    <titlePG><![CDATA[' . htmlspecialchars($title, ENT_NOQUOTES) . ']]></titlePG>
 	    <shortdescPG><![CDATA[' . htmlspecialchars($comment) . ']]></shortdescPG>
 	    <longdescPG><![CDATA[' . htmlspecialchars($comment) . ']]></longdescPG>
 	    <imgPG></imgPG>

--- a/PodcastGenerator/admin/episodes_upload.php
+++ b/PodcastGenerator/admin/episodes_upload.php
@@ -139,7 +139,7 @@ if (sizeof($_POST) > 0) {
     $episodefeed = '<?xml version="1.0" encoding="utf-8"?>
 <PodcastGenerator>
 	<episode>
-	    <titlePG><![CDATA[' . htmlspecialchars($_POST['title']) . ']]></titlePG>
+	    <titlePG><![CDATA[' . htmlspecialchars($_POST['title'], ENT_NOQUOTES) . ']]></titlePG>
 	    <shortdescPG><![CDATA[' . htmlspecialchars($_POST['shortdesc']) . ']]></shortdescPG>
 	    <longdescPG><![CDATA[' . htmlspecialchars($_POST['longdesc']) . ']]></longdescPG>
 	    <imgPG></imgPG>


### PR DESCRIPTION
This PR is to fix #304 and allow for quotes in the title of a podcast, we will still check for all other types of code in the string however this will allow for single and double quotes only. 
 
@emilengler this should be pretty simple to merge I hope.

* [x] I am the author of this code or the code is public domain
* [x] I release this code into the public domain
