### PR TITLE
Fixing #296 & #297

### DIFF
--- a/PodcastGenerator/admin/episodes_edit.php
+++ b/PodcastGenerator/admin/episodes_edit.php
@@ -103,7 +103,7 @@ if (sizeof($_POST) > 0) {
     $episodefeed = '<?xml version="1.0" encoding="utf-8"?>
 <PodcastGenerator>
 	<episode>
-	    <titlePG><![CDATA[' . htmlspecialchars($_POST['title']) . ']]></titlePG>
+	    <titlePG><![CDATA[' . htmlspecialchars($_POST['title'], ENT_NOQUOTES) . ']]></titlePG>
 	    <shortdescPG><![CDATA[' . htmlspecialchars($_POST['shortdesc']) . ']]></shortdescPG>
 	    <longdescPG><![CDATA[' . htmlspecialchars($long_desc) . ']]></longdescPG>
 	    <imgPG></imgPG>

--- a/PodcastGenerator/admin/episodes_ftp_feature.php
+++ b/PodcastGenerator/admin/episodes_ftp_feature.php
@@ -72,12 +72,6 @@ if (isset($_GET['start'])) {
     // Generate XML from audio file (with mostly empty values)
     $num_added = 0;
     for ($i = 0; $i < sizeof($new_files); $i++) {
-        // Skip files if they are not strictly named
-        if ($config['strictfilenamepolicy'] == 'yes') {
-            if (!preg_match('/^[\-\w.\x7f-\xff ]+$/', $new_files[$i])) {
-                continue;
-            }
-        }
         // Get audio metadata (duration, bitrate etc)
         $getID3 = new getID3;
         $fileinfo = $getID3->analyze('../' . $config['upload_dir'] . $new_files[$i]);

--- a/PodcastGenerator/admin/episodes_ftp_feature.php
+++ b/PodcastGenerator/admin/episodes_ftp_feature.php
@@ -85,7 +85,7 @@ if (isset($_GET['start'])) {
         $episodefeed = '<?xml version="1.0" encoding="utf-8"?>
 <PodcastGenerator>
 	<episode>
-	    <titlePG><![CDATA[' . htmlspecialchars($title) . ']]></titlePG>
+	    <titlePG><![CDATA[' . htmlspecialchars($title, ENT_NOQUOTES) . ']]></titlePG>
 	    <shortdescPG><![CDATA[' . htmlspecialchars($comment) . ']]></shortdescPG>
 	    <longdescPG><![CDATA[' . htmlspecialchars($comment) . ']]></longdescPG>
 	    <imgPG></imgPG>

--- a/PodcastGenerator/admin/episodes_ftp_feature.php
+++ b/PodcastGenerator/admin/episodes_ftp_feature.php
@@ -72,6 +72,9 @@ if (isset($_GET['start'])) {
     // Generate XML from audio file (with mostly empty values)
     $num_added = 0;
     for ($i = 0; $i < sizeof($new_files); $i++) {
+        // ensure the filename is in UTF-8 encoding
+        $new_files[$i] = mb_convert_encoding($new_files[$i], 'UTF-8', mb_detect_encoding($new_files[$i]));
+
         // Get audio metadata (duration, bitrate etc)
         $getID3 = new getID3;
         $fileinfo = $getID3->analyze('../' . $config['upload_dir'] . $new_files[$i]);

--- a/PodcastGenerator/admin/episodes_ftp_feature.php
+++ b/PodcastGenerator/admin/episodes_ftp_feature.php
@@ -68,7 +68,7 @@ if (isset($_GET['start'])) {
     for ($i = 0; $i < sizeof($new_files); $i++) {
         // Skip files if they are not strictly named
         if ($config['strictfilenamepolicy'] == 'yes') {
-            if (!preg_match('/^[\w.]+$/', $new_files[$i])) {
+            if (!preg_match('/^[\-\w.\x7f-\xff ]+$/', $new_files[$i])) {
                 continue;
             }
         }

--- a/PodcastGenerator/admin/episodes_upload.php
+++ b/PodcastGenerator/admin/episodes_upload.php
@@ -59,9 +59,6 @@ if (sizeof($_POST) > 0) {
     }
 
     $targetfile = '../' . $config['upload_dir'] . $_POST['date'] . '_' . basename($_FILES['file']['name']);
-    // ensure the filename is in UTF-8 encoding
-    $targetfile = mb_convert_encoding($targetfile, 'UTF-8', mb_detect_encoding($targetfile));
-
     $targetfile = str_replace(' ', '_', $targetfile);
     if (file_exists($targetfile)) {
         $appendix = 1;
@@ -73,6 +70,9 @@ if (sizeof($_POST) > 0) {
     }
     $targetfile = strtolower($targetfile);
     $targetfile_without_ext = strtolower('../' . $config['upload_dir'] . pathinfo($targetfile, PATHINFO_FILENAME));
+
+    // ensure the filename is in UTF-8 encoding
+    $targetfile = mb_convert_encoding($targetfile, 'UTF-8', mb_detect_encoding($targetfile));
 
     $validTypes = simplexml_load_file('../components/supported_media/supported_media.xml');
     $fileextension = pathinfo($targetfile, PATHINFO_EXTENSION);

--- a/PodcastGenerator/admin/episodes_upload.php
+++ b/PodcastGenerator/admin/episodes_upload.php
@@ -62,8 +62,8 @@ if (sizeof($_POST) > 0) {
 
     // Skip files if they are not strictly named
     if ($config['strictfilenamepolicy'] == 'yes') {
-        if (!preg_match('/^[\w.]+$/', basename($_FILES['file']['name']))) {
-            $error = _('Invalid filename, only A-Z, a-z, underscores and dots are permitted');
+        if (!preg_match('/^[\-\w.\x7f-\xff ]+$/', basename($_FILES['file']['name']))) {
+            $error = _('Invalid filename, only A-Z, a-z, underscores, dashes and dots are permitted. Along with language specific characters and accents.');
             goto error;
         }
     }

--- a/PodcastGenerator/admin/episodes_upload.php
+++ b/PodcastGenerator/admin/episodes_upload.php
@@ -59,6 +59,9 @@ if (sizeof($_POST) > 0) {
     }
 
     $targetfile = '../' . $config['upload_dir'] . $_POST['date'] . '_' . basename($_FILES['file']['name']);
+    // ensure the filename is in UTF-8 encoding
+    $targetfile = mb_convert_encoding($targetfile, 'UTF-8', mb_detect_encoding($targetfile));
+
     $targetfile = str_replace(' ', '_', $targetfile);
     if (file_exists($targetfile)) {
         $appendix = 1;

--- a/PodcastGenerator/admin/episodes_upload.php
+++ b/PodcastGenerator/admin/episodes_upload.php
@@ -58,14 +58,6 @@ if (sizeof($_POST) > 0) {
         goto error;
     }
 
-    // Skip files if they are not strictly named
-    if ($config['strictfilenamepolicy'] == 'yes') {
-        if (!preg_match('/^[\-\w.\x7f-\xff ]+$/', basename($_FILES['file']['name']))) {
-            $error = _('Invalid filename, only A-Z, a-z, underscores, dashes and dots are permitted. Along with language specific characters and accents.');
-            goto error;
-        }
-    }
-
     $targetfile = '../' . $config['upload_dir'] . $_POST['date'] . '_' . basename($_FILES['file']['name']);
     $targetfile = str_replace(' ', '_', $targetfile);
     if (file_exists($targetfile)) {

--- a/PodcastGenerator/admin/episodes_upload.php
+++ b/PodcastGenerator/admin/episodes_upload.php
@@ -139,7 +139,7 @@ if (sizeof($_POST) > 0) {
     $episodefeed = '<?xml version="1.0" encoding="utf-8"?>
 <PodcastGenerator>
 	<episode>
-	    <titlePG><![CDATA[' . htmlspecialchars($_POST['title']) . ']]></titlePG>
+	    <titlePG><![CDATA[' . htmlspecialchars($_POST['title'], ENT_NOQUOTES) . ']]></titlePG>
 	    <shortdescPG><![CDATA[' . htmlspecialchars($_POST['shortdesc']) . ']]></shortdescPG>
 	    <longdescPG><![CDATA[' . htmlspecialchars($_POST['longdesc']) . ']]></longdescPG>
 	    <imgPG></imgPG>

--- a/PodcastGenerator/core/backwards.php
+++ b/PodcastGenerator/core/backwards.php
@@ -48,8 +48,6 @@ function backwards_3_1_to_3_2($absoluteurl)
 
 \$enablepgnewsinadmin = \"".$config['enablepgnewsinadmin']."\";
 
-\$strictfilenamepolicy = \"".$config['strictfilenamepolicy']."\"; // strictly rename files (just characters A to Z and numbers) 
-
 \$categoriesenabled = \"".$config['categoriesenabled']."\";
 
 \$cronAutoIndex = ".$config['cronAutoIndex']."; //Auto Index New Episodes via Cron


### PR DESCRIPTION
Adding additional characters to the `$strictfilenamepolicy` config to allow for dashes and other European characters. This should help fix #296 & fix #297

* [x] I am the author of this code or the code is public domain
* [x] I release this code into the public domain
