### PR TITLE
feat(themes/default): add HTML <link> tag for podcast feed

### DIFF
--- a/PodcastGenerator/themes/default/index.php
+++ b/PodcastGenerator/themes/default/index.php
@@ -12,7 +12,7 @@
     <meta name="description" content="<?php echo htmlspecialchars($config["podcast_subtitle"]); ?>">
     <meta name="author" content="<?php echo htmlspecialchars($config["author_name"]); ?>">
     <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
-    <link rel="alternate" type="application/rss+xml" title="Subscribe to <?php echo htmlspecialchars($config["podcast_title"]); ?>" href="feed.php">
+    <link rel="alternate" type="application/rss+xml" title="Subscribe to <?php echo htmlspecialchars($config["podcast_title"]); ?>" href="feed.xml">
 
     <!--    Add meta propreties for social cards, depends if it's for the main page ou a single episode -->
     <?php

--- a/PodcastGenerator/themes/default/index.php
+++ b/PodcastGenerator/themes/default/index.php
@@ -12,6 +12,7 @@
     <meta name="description" content="<?php echo htmlspecialchars($config["podcast_subtitle"]); ?>">
     <meta name="author" content="<?php echo htmlspecialchars($config["author_name"]); ?>">
     <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
+    <link rel="alternate" type="application/rss+xml" title="Subscribe to <?php echo htmlspecialchars($config["podcast_title"]); ?>" href="feed.php">
 
     <!--    Add meta propreties for social cards, depends if it's for the main page ou a single episode -->
     <?php


### PR DESCRIPTION
Add a link element in the page `<head>` that references the podcast RSS feed via feed.php.

* [x] I am the author of this code or the code is public domain
* [x] I release this code under the [GPL-3.0 License](https://github.com/PodcastGenerator/PodcastGenerator/blob/master/LICENSE)
