### PR TITLE
fix(feed.php): properly get feed.xml contents

### DIFF
--- a/PodcastGenerator/feed.php
+++ b/PodcastGenerator/feed.php
@@ -17,6 +17,6 @@ if($config['podcastPassword'] != "") {
 }
 header('Content-Type: application/xml');
 sleep(0.01);
-$xml = file_get_contents($config['absoluteurl'] . $config['feed_dir']) . 'feed.xml';
+$xml = file_get_contents($config['absoluteurl'] . $config['feed_dir'] . 'feed.xml');
 echo $xml;
 ?>


### PR DESCRIPTION
It helps if the correct path is passed into `feed_get_contents()`

* [x] I am the author of this code or the code is public domain
* [x] I release this code under the [GPL-3.0 License](https://github.com/PodcastGenerator/PodcastGenerator/blob/master/LICENSE)
