### PR TITLE
Immutable item GUIDs

### DIFF
--- a/PodcastGenerator/admin/episodes_edit.php
+++ b/PodcastGenerator/admin/episodes_edit.php
@@ -85,6 +85,10 @@ if (sizeof($_POST) > 0) {
         goto error;
     }
 
+    $link = str_replace('?', '', $config['link']);
+    $link = str_replace('=', '', $link);
+    $link = str_replace('$url', '', $link);
+
     $targetfile = $config['absoluteurl'] . $config['upload_dir'] . $_GET['name'];
 
     // Get datetime
@@ -103,12 +107,16 @@ if (sizeof($_POST) > 0) {
     // Automatically fill an empty long description with the contents
     // of the short description.
     $long_desc = empty($_POST['longdesc']) ? $_POST['shortdesc'] : $_POST['longdesc'];
-        
+
+    // Regenerate GUID if it is missing from POST data
+    $guid = empty($_POST['guid']) ? $config['url'] . "?" . $link . "=" . $_GET['name'] : $_POST['guid'];
+
     // Go and actually generate the episode
     // It easier to not dynamically generate the file
     $episodefeed = '<?xml version="1.0" encoding="utf-8"?>
 <PodcastGenerator>
 	<episode>
+	    <guid>' . htmlspecialchars($guid) . '</guid>
 	    <titlePG>' . htmlspecialchars($_POST['title'], ENT_NOQUOTES) . '</titlePG>
 	    <shortdescPG><![CDATA[' . $_POST['shortdesc'] . ']]></shortdescPG>
 	    <longdescPG><![CDATA[' . $long_desc . ']]></longdescPG>
@@ -172,6 +180,7 @@ $episode = simplexml_load_file($config['absoluteurl'] . $config['upload_dir'] . 
                 <div class="col-6">
                     <h3><?php echo _('Main Information'); ?></h3>
                     <hr>
+                    <input type="hidden" name="guid" value="<?php echo htmlspecialchars($episode->episode->guid); ?>">
                     <div class="form-group">
                         <?php echo _('Title'); ?>*:<br>
                         <input type="text" name="title" class="form-control" value="<?php echo htmlspecialchars($episode->episode->titlePG); ?>" required>

--- a/PodcastGenerator/admin/episodes_upload.php
+++ b/PodcastGenerator/admin/episodes_upload.php
@@ -67,6 +67,10 @@ if (sizeof($_POST) > 0) {
         }
     }
 
+    $link = str_replace('?', '', $config['link']);
+    $link = str_replace('=', '', $link);
+    $link = str_replace('$url', '', $link);
+
     $targetfile = '../' . $config['upload_dir'] . $_POST['date'] . '_' . basename($_FILES['file']['name']);
     $targetfile = str_replace(' ', '_', $targetfile);
     if (file_exists($targetfile)) {
@@ -139,6 +143,7 @@ if (sizeof($_POST) > 0) {
     $episodefeed = '<?xml version="1.0" encoding="utf-8"?>
 <PodcastGenerator>
 	<episode>
+	    <guid>' . htmlspecialchars($config['url'] . "?" . $link . "=" . $targetfile) . '</guid>
 	    <titlePG>' . htmlspecialchars($_POST['title'], ENT_NOQUOTES) . '</titlePG>
 	    <shortdescPG><![CDATA[' . $_POST['shortdesc'] . ']]></shortdescPG>
 	    <longdescPG><![CDATA[' . $_POST['longdesc'] . ']]></longdescPG>

--- a/PodcastGenerator/core/feed_generator.php
+++ b/PodcastGenerator/core/feed_generator.php
@@ -122,6 +122,8 @@ function generateRSS()
         } else {
             $author = $config['author_email'] . ' (' . $config['author_name'] . ')';
         }
+        // Generate GUID if a pregenerated GUID is missing for the episode
+        $guid = isset($file->episode->guid) ? $file->episode->guid : $config['url'] . "?" . $link . "=" . $files[$i]['filename'];
         // Check if this episode has a cover art
         $basename = pathinfo($config['absoluteurl'] . $config['upload_dir'] . $files[$i]['filename'], PATHINFO_FILENAME);
         $has_cover = false;
@@ -143,7 +145,7 @@ function generateRSS()
         }
         $item .= $indent . '<link>' . $config['url'] . '?' . $link . '=' . $files[$i]['filename'] . '</link>' . $linebreak;
         $item .= $indent . '<enclosure url="' . $original_full_filepath . '" length="' . filesize($config['absoluteurl'] . $config['upload_dir'] . $files[$i]['filename']) . '" type="' . $mimetype . '"></enclosure>' . $linebreak;
-        $item .= $indent . '<guid>' . $config['url'] . "?" . $link . "=" . $files[$i]['filename'] . '</guid>' . $linebreak;
+        $item .= $indent . '<guid>' . $guid . '</guid>' . $linebreak;
         $item .= $indent . '<itunes:duration>' . $file->episode->fileInfoPG->duration . '</itunes:duration>' . $linebreak;
         $item .= $indent . '<author>' . htmlspecialchars($author) . '</author>' . $linebreak;
         if (!empty($file->episode->authorPG->namePG)) {


### PR DESCRIPTION
This moves GUID generation for episodes out of feed_generator.php and into the episode upload and edit pages, so that immutability of the `<guid>` element can be maintained. Fixes #370.

* [x] I am the author of this code or the code is public domain
* [x] I release this code under the [GPL-3.0 License](https://github.com/PodcastGenerator/PodcastGenerator/blob/master/LICENSE)