### PR TITLE
Add Open Graph audio/video property on single-episode pages

### DIFF
--- a/PodcastGenerator/themes/default/index.php
+++ b/PodcastGenerator/themes/default/index.php
@@ -43,8 +43,23 @@
         echo '    <meta property="og:url" content="' . $config["url"] . 'index.php?name=' . $correctepisode["episode"]["filename"] . '" />' . "\n";
         echo '    <meta property="og:image" content="' . $img . '" />' . "\n";
         echo '    <meta property="og:description" content="' . $config["podcast_description"] . '" />' . "\n";
-        if (strtolower($config["enablestreaming"]) == "yes" && ($type == 'audio' || $type == 'video')) {
-            echo '    <meta property="og:' . $type . '" src="' . $config["upload_dir"] . $correctepisode["episode"]["filename"] . '" />' . "\n";
+        if (strtolower($config["enablestreaming"]) == "yes") {
+            // Get mime
+            $mime = getmime($config["absoluteurl"] . $config["upload_dir"] . $correctepisode["episode"]["filename"]);
+            if (!$mime)
+                $mime = null;
+            $type = '';
+            if (substr($mime, 0, 5) == 'video') {
+                $type = 'video';
+            } elseif (substr($mime, 0, 5) == 'audio' || $mime == 'application/ogg') {
+                $type = 'audio';
+            }
+            if ($type == 'audio' || $type == 'video') {
+                echo '    <meta property="og:' . $type . '" content="' . $config["upload_dir"] . $correctepisode["episode"]["filename"] . '" />' . "\n";
+                if ($mime) {
+                    echo '    <meta property="og:' . $type . ':type" content="' . $mime . '" />' . "\n";
+                }
+            }
         }
     } else {
         echo '    <meta property="og:title" content="' . $config["podcast_title"] . '" />' . "\n";

--- a/PodcastGenerator/themes/default/index.php
+++ b/PodcastGenerator/themes/default/index.php
@@ -55,7 +55,7 @@
                 $type = 'audio';
             }
             if ($type == 'audio' || $type == 'video') {
-                echo '    <meta property="og:' . $type . '" content="' . $config["upload_dir"] . $correctepisode["episode"]["filename"] . '" />' . "\n";
+                echo '    <meta property="og:' . $type . '" content="' . $config["url"] . $config["upload_dir"] . $correctepisode["episode"]["filename"] . '" />' . "\n";
                 if ($mime) {
                     echo '    <meta property="og:' . $type . ':type" content="' . $mime . '" />' . "\n";
                 }

--- a/PodcastGenerator/themes/default/index.php
+++ b/PodcastGenerator/themes/default/index.php
@@ -43,6 +43,9 @@
         echo '    <meta property="og:url" content="' . $config["url"] . 'index.php?name=' . $correctepisode["episode"]["filename"] . '" />' . "\n";
         echo '    <meta property="og:image" content="' . $img . '" />' . "\n";
         echo '    <meta property="og:description" content="' . $config["podcast_description"] . '" />' . "\n";
+        if (strtolower($config["enablestreaming"]) == "yes" && ($type == 'audio' || $type == 'video')) {
+            echo '    <meta property="og:' . $type . '" src="' . $config["upload_dir"] . $correctepisode["episode"]["filename"] . '" />' . "\n";
+        }
     } else {
         echo '    <meta property="og:title" content="' . $config["podcast_title"] . '" />' . "\n";
         echo '    <meta property="og:type" content="article" />' . "\n";


### PR DESCRIPTION
Make it easier for services which consume Open Graph data to embed a podcast episode when linked to an individual episode's page by adding the og:audio or og:video property, as appropriate, to the page's metadata tags.

<!-- Please check all checkboxes by putting a 'x' into it. Example: [x] -->

* [x] I am the author of this code or the code is public domain
* [x] I release this code under the [GPL-3.0 License](https://github.com/PodcastGenerator/PodcastGenerator/blob/master/LICENSE)
