### PR TITLE
fix: make explicit content option labels usable

### DIFF
--- a/PodcastGenerator/admin/episodes_edit.php
+++ b/PodcastGenerator/admin/episodes_edit.php
@@ -214,7 +214,8 @@ $episode = simplexml_load_file('../' . $config['upload_dir'] . pathinfo('../' . 
                     </div>
                     <div class="form-group">
                         <?php echo _('Explicit Content'); ?>:<br>
-                        <input type="radio" value="yes" name="explicit" <?php if($episode->episode->explicitPG == 'yes') { echo 'checked'; } ?>> Yes <input type="radio" value="no" name="explicit" <?php if($episode->episode->explicitPG == 'no') { echo 'checked'; } ?>> No<br>
+                        <label><input type="radio" value="yes" name="explicit" <?php if($episode->episode->explicitPG == 'yes') { echo 'checked'; } ?>> <?php echo _('Yes'); ?></label>
+                        <label><input type="radio" value="no" name="explicit" <?php if($episode->episode->explicitPG == 'no') { echo 'checked'; } ?>> <?php echo _('No'); ?></label><br>
                     </div>
                     <div class="form-group">
                         <?php echo _('Author'); ?>*:<br>

--- a/PodcastGenerator/admin/episodes_upload.php
+++ b/PodcastGenerator/admin/episodes_upload.php
@@ -253,7 +253,8 @@ if (sizeof($_POST) > 0) {
                     </div>
                     <div class="form-group">
                         <?php echo _('Explicit content'); ?>:<br>
-                        <input type="radio" value="yes" name="explicit"> <?php echo _('Yes'); ?> <input type="radio" value="no" name="explicit" checked> <?php echo _('No'); ?><br>
+                        <label><input type="radio" value="yes" name="explicit"> <?php echo _('Yes'); ?></label>
+                        <label><input type="radio" value="no" name="explicit" checked> <?php echo _('No'); ?></label><br>
                     </div>
                     <div class="form-group">
                         <?php echo _('Author'); ?>*:<br>


### PR DESCRIPTION
This makes some fixes to the episode upload and edit admin pages, so that the "Yes" and "No" labels for the "Explicit Content" radio buttons can be clicked to set the options.

* [x] I am the author of this code or the code is public domain
* [x] I release this code under the [GPL-3.0 License](https://github.com/PodcastGenerator/PodcastGenerator/blob/master/LICENSE)