### PR TITLE
default theme: Add a dark variant

### DIFF
--- a/PodcastGenerator/themes/default/categories.php
+++ b/PodcastGenerator/themes/default/categories.php
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="<?php echo htmlspecialchars($config["theme_path"]); ?>style/bootstrap.css">
     <link rel="stylesheet" href="<?php echo htmlspecialchars($config["theme_path"]); ?>style/custom.css">
     <link rel="stylesheet" href="<?php echo htmlspecialchars($config["theme_path"]); ?>style/font-awesome.min.css">
+    <link rel="stylesheet" href="<?php echo htmlspecialchars($config["theme_path"]); ?>style/dark.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
 </head>

--- a/PodcastGenerator/themes/default/index.php
+++ b/PodcastGenerator/themes/default/index.php
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="<?php echo htmlspecialchars($config["theme_path"]); ?>style/bootstrap.css">
     <link rel="stylesheet" href="<?php echo htmlspecialchars($config["theme_path"]); ?>style/custom.css">
     <link rel="stylesheet" href="<?php echo htmlspecialchars($config["theme_path"]); ?>style/font-awesome.min.css">
+    <link rel="stylesheet" href="<?php echo htmlspecialchars($config["theme_path"]); ?>style/dark.css">
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/PodcastGenerator/themes/default/style/dark.css
+++ b/PodcastGenerator/themes/default/style/dark.css
@@ -1,0 +1,20 @@
+@media (prefers-color-scheme: dark) {
+	body {
+		background-color: #1c1c1c;
+		color: #ccc;
+	}
+
+	.card {
+		background-color: #282828;
+		color: #ccc;
+	}
+
+	.page-link {
+		background-color: #282828;
+		border-color: #555;
+	}
+
+	.jumbotron {
+		background-color: #282828;
+	}
+}


### PR DESCRIPTION
This uses CSS media queries in order to test based on the user’s
preferences, see MDN:
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme

I’ve only tested it on a simple podcast, feel free to suggest changes,
or to point to missing parts!

This supersedes #353 and #363.

<!-- Please check all checkboxes by putting a 'x' into it. Example: [x] -->

* [x] I am the author of this code or the code is public domain
* [x] I release this code into the public domain
