### PR TITLE
Add a French translation

### DIFF
--- a/PodcastGenerator/components/locale/fr_FR/LC_MESSAGES/messages.po
+++ b/PodcastGenerator/components/locale/fr_FR/LC_MESSAGES/messages.po
@@ -1,0 +1,839 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR The Podcast Generator Translation Team
+# This file is distributed under the same license as the Podcast Generator package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Podcast Generator \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-30 11:39+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: PodcastGenerator/admin/episodes_bulk.php:37
+#: PodcastGenerator/admin/navbar.php:20
+msgid "Bulk download episodes"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_bulk.php:50
+msgid ""
+"If you want to bulk download all episodes, you need to have curl installed.\n"
+"        On Windows 10, macOS and most Linux distributions it is already pre-installed. Please\n"
+"        open your Terminal app on macOS and Linux or open the start menu and search for cmd.exe on Windows.\n"
+"        After this paste the following (long) command into the terminal/cmd.exe and press enter."
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:14
+msgid "No name given"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:17
+msgid "Episode does not exist"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:42
+#: PodcastGenerator/admin/episodes_upload.php:15
+msgid "Empty title"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:46
+#: PodcastGenerator/admin/episodes_upload.php:19
+msgid "Empty Short Description"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:50
+#: PodcastGenerator/admin/episodes_upload.php:23
+msgid "Empty Date"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:54
+#: PodcastGenerator/admin/episodes_upload.php:27
+msgid "Empty explicit value"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:58
+#: PodcastGenerator/admin/episodes_upload.php:31
+msgid "Empty author name"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:62
+#: PodcastGenerator/admin/episodes_upload.php:35
+msgid "Empty author email"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:73
+#: PodcastGenerator/admin/episodes_upload.php:46
+msgid "Too many categories selected (max: 3)"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:80
+#: PodcastGenerator/admin/episodes_upload.php:60
+msgid "Invalid Author E-Mail provided"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:86
+#: PodcastGenerator/admin/episodes_upload.php:66
+msgid "Size of the 'Short Description' exceeded"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:152
+#: PodcastGenerator/admin/episodes_edit.php:166
+msgid "Edit Episode"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:174
+msgid "Main Information"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:177
+#: PodcastGenerator/admin/episodes_upload.php:222
+msgid "Title"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:181
+#: PodcastGenerator/admin/episodes_upload.php:226
+msgid "Short Description"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:183
+msgid " characters remaining"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:186
+#: PodcastGenerator/admin/episodes_upload.php:231
+#: PodcastGenerator/admin/store_cat.php:56
+#: PodcastGenerator/admin/store_cat.php:69
+#: PodcastGenerator/admin/store_cat.php:87
+msgid "Category"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:187
+#: PodcastGenerator/admin/episodes_upload.php:232
+msgid "You can select up to 3 categories"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:204
+#: PodcastGenerator/admin/episodes_upload.php:243
+msgid "Publication Date"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:205
+#: PodcastGenerator/admin/episodes_upload.php:244
+msgid "If you select a date in the future, it will be published then"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:206
+#: PodcastGenerator/admin/episodes_upload.php:245
+msgid "Date"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:208
+#: PodcastGenerator/admin/episodes_upload.php:247
+msgid "Time"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:213
+msgid "Extra Information"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:216
+#: PodcastGenerator/admin/episodes_upload.php:255
+msgid "Long Description"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:220
+#: PodcastGenerator/admin/episodes_upload.php:259
+msgid "iTunes Keywords"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:224
+msgid "Explicit Content"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:228
+#: PodcastGenerator/admin/episodes_upload.php:267
+msgid "Author"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:232
+msgid "Save Changes"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:237
+msgid "Delete Episode"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_edit.php:244
+msgid "\" characters remaining\""
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_ftp_feature.php:139
+#, php-format
+msgid "Added %d new episode(s)"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_ftp_feature.php:141
+msgid "No new episodes were found"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_ftp_feature.php:149
+msgid "FTP Feature"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_ftp_feature.php:163
+msgid "FTP Auto Indexing"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_ftp_feature.php:166
+msgid "Begin"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_manage_cats.php:40
+msgid "Category already exists"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_manage_cats.php:62
+#: PodcastGenerator/admin/episodes_manage_cats.php:76
+#: PodcastGenerator/admin/navbar.php:18
+msgid "Manage categories"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_manage_cats.php:77
+msgid "Add category"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_manage_cats.php:79
+#: PodcastGenerator/admin/episodes_manage_cats.php:80
+msgid "Category Name"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_manage_cats.php:81
+msgid "Add"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_manage_cats.php:83
+msgid "Current Categories"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_manage_cats.php:88
+msgid "Delete"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_regenerate.php:19
+msgid "Regenerate Feed"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_regenerate.php:33
+msgid "Successfully regenerated RSS feed"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_regenerate.php:34
+msgid "Return"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_upload.php:73
+msgid "Invalid filename, only A-Z, a-z, underscores and dots are permitted"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_upload.php:100
+msgid "Invalid file extension"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_upload.php:105
+msgid "The file upload was not successfully"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_upload.php:112
+msgid "The uploaded file is not readable (permission error)"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_upload.php:125
+#, php-format
+msgid "Unsupported mime type detected for file with extension \"%s\""
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_upload.php:189
+#: PodcastGenerator/admin/episodes_upload.php:203
+msgid "Upload Episode"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_upload.php:206
+msgid "uploaded successfully"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_upload.php:215
+msgid "Main Informations"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_upload.php:218
+msgid "File"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_upload.php:228
+#: PodcastGenerator/admin/episodes_upload.php:280
+msgid "characters remaining"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_upload.php:252
+msgid "Extra Informations"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_upload.php:263
+msgid "Explicit content"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_upload.php:264
+#: PodcastGenerator/admin/pg_config.php:43
+#: PodcastGenerator/admin/pg_config.php:47
+#: PodcastGenerator/admin/pg_config.php:51
+#: PodcastGenerator/admin/podcast_details.php:137
+msgid "Yes"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_upload.php:264
+#: PodcastGenerator/admin/pg_config.php:43
+#: PodcastGenerator/admin/pg_config.php:47
+#: PodcastGenerator/admin/pg_config.php:51
+#: PodcastGenerator/admin/podcast_details.php:137
+msgid "No"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_upload.php:268
+#: PodcastGenerator/admin/podcast_details.php:56
+msgid "Author Name"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_upload.php:269
+msgid "Author E-Mail"
+msgstr ""
+
+#: PodcastGenerator/admin/episodes_upload.php:271
+msgid "Upload episode"
+msgstr ""
+
+#: PodcastGenerator/admin/forgot.php:4
+msgid "Password Reset"
+msgstr ""
+
+#: PodcastGenerator/admin/forgot.php:12
+msgid "Reset your password"
+msgstr ""
+
+#: PodcastGenerator/admin/forgot.php:13
+msgid "No password, no problem!"
+msgstr ""
+
+#: PodcastGenerator/admin/forgot.php:16
+msgid "We offer a tool which allows you to easily recover your password. However, the danger of this is that as long as this file is online, anyone can reset this password so this file shouldn't be online that long."
+msgstr ""
+
+#: PodcastGenerator/admin/forgot.php:18
+#, php-format
+msgid "In the ZIP file of this version which you downloaded there is a file in the %s folder called %s. Upload this file to into the admin directory with the name %s"
+msgstr ""
+
+#: PodcastGenerator/admin/forgot.php:19
+msgid "If you no don't have this ZIP file anymore, don't worry! All versions of Podcast Generator ever released since 2.5 are available on the Podcast Generator Homepage."
+msgstr ""
+
+#: PodcastGenerator/admin/index.php:37
+msgid "Welcome to your Podcast Generator Admin Interface"
+msgstr ""
+
+#: PodcastGenerator/admin/login.php:24
+msgid "Login disabled for security reasons"
+msgstr ""
+
+#: PodcastGenerator/admin/login.php:29 PodcastGenerator/admin/pg_users.php:49
+msgid "Missing fields"
+msgstr ""
+
+#: PodcastGenerator/admin/login.php:37
+msgid "Invalid username or password"
+msgstr ""
+
+#: PodcastGenerator/admin/login.php:62 PodcastGenerator/admin/pg_users.php:99
+#: PodcastGenerator/admin/pg_users.php:116
+msgid "Username"
+msgstr ""
+
+#: PodcastGenerator/admin/login.php:64 PodcastGenerator/admin/pg_users.php:101
+msgid "Password"
+msgstr ""
+
+#: PodcastGenerator/admin/login.php:66
+msgid "Forgot Password?"
+msgstr ""
+
+#: PodcastGenerator/admin/login.php:68
+msgid "Sign In"
+msgstr ""
+
+#: PodcastGenerator/admin/navbar.php:3
+msgid "Toggle navigation"
+msgstr ""
+
+#: PodcastGenerator/admin/navbar.php:13
+msgid "Episodes"
+msgstr ""
+
+#: PodcastGenerator/admin/navbar.php:16
+msgid "Upload New Episodes"
+msgstr ""
+
+#: PodcastGenerator/admin/navbar.php:17
+msgid "Edit / Delete Episode"
+msgstr ""
+
+#: PodcastGenerator/admin/navbar.php:19
+msgid "FTP Feature (Auto Indexing)"
+msgstr ""
+
+#: PodcastGenerator/admin/navbar.php:21
+msgid "Manually regenerate RSS feed"
+msgstr ""
+
+#: PodcastGenerator/admin/navbar.php:26
+msgid "Themes and aspect"
+msgstr ""
+
+#: PodcastGenerator/admin/navbar.php:29
+msgid "Change Theme"
+msgstr ""
+
+#: PodcastGenerator/admin/navbar.php:30
+msgid "Customize your Freebox"
+msgstr ""
+
+#: PodcastGenerator/admin/navbar.php:31
+#: PodcastGenerator/admin/theme_buttons.php:98
+msgid "Change Buttons"
+msgstr ""
+
+#: PodcastGenerator/admin/navbar.php:36
+msgid "Podcast Platform Settings"
+msgstr ""
+
+#: PodcastGenerator/admin/navbar.php:39
+msgid "Change Cover Art"
+msgstr ""
+
+#: PodcastGenerator/admin/navbar.php:40
+msgid "Change Podcast Category"
+msgstr ""
+
+#: PodcastGenerator/admin/navbar.php:45
+#: PodcastGenerator/admin/podcast_details.php:27
+msgid "Podcast Details"
+msgstr ""
+
+#: PodcastGenerator/admin/navbar.php:48
+msgid "Change Podcast details"
+msgstr ""
+
+#: PodcastGenerator/admin/navbar.php:53
+msgid "Podcast Generator"
+msgstr ""
+
+#: PodcastGenerator/admin/navbar.php:56
+msgid "Change Podcast Generator Config"
+msgstr ""
+
+#: PodcastGenerator/admin/navbar.php:57 PodcastGenerator/admin/pg_users.php:64
+#: PodcastGenerator/admin/pg_users.php:78
+msgid "Manage users"
+msgstr ""
+
+#: PodcastGenerator/admin/navbar.php:63
+msgid "View Podcast"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_config.php:25
+msgid "Podcast Generator Configuration"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_config.php:39
+msgid "Change Podcast Generator Configuration"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_config.php:41
+msgid "Enable Audio and Video Player"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_config.php:42
+msgid "Enable streaming in web browser"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_config.php:45
+#: PodcastGenerator/admin/theme_freebox.php:63
+msgid "Enable Freebox"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_config.php:46
+msgid "Freebox allows you to write freely what you wish, add links or text through a visual editor in the admin section."
+msgstr ""
+
+#: PodcastGenerator/admin/pg_config.php:49
+msgid "Enable categories"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_config.php:50
+msgid "Enable categories feature to make thematic lists of your podcasts."
+msgstr ""
+
+#: PodcastGenerator/admin/pg_config.php:53
+msgid "Use cron to regenerate the RSS feed"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_config.php:56
+msgid "Password Protection for the web pages"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_config.php:57
+msgid "Leave empty for no password, keep in mind that the feed and the audio files will still be accessible no matter if a password is set or not"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_config.php:60
+#: PodcastGenerator/admin/pg_users.php:104
+#: PodcastGenerator/admin/podcast_details.php:139
+#: PodcastGenerator/admin/theme_buttons.php:127
+#: PodcastGenerator/admin/theme_buttons.php:148
+msgid "Submit"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_users.php:18
+msgid "Error while changing password"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_users.php:30
+#: PodcastGenerator/admin/pg_users.php:130
+msgid "You cannot delete yourself"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_users.php:35
+msgid "User does not exists"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_users.php:39
+msgid "Unknown error while deleting user"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_users.php:53
+msgid "Error while creating user"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_users.php:79
+msgid "It may take a few seconds until the changes are visible"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_users.php:82
+msgid "User changed successfully"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_users.php:84
+msgid "User created successfully"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_users.php:86
+msgid "User deleted successfully"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_users.php:90
+msgid "List of users"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_users.php:97
+msgid "Create User"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_users.php:111
+msgid "User does not exist"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_users.php:117
+msgid "You cannot edit usernames"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_users.php:118
+msgid "New Password"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_users.php:120
+msgid "Repeat new password"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_users.php:123
+msgid "Change"
+msgstr ""
+
+#: PodcastGenerator/admin/pg_users.php:126
+msgid "Delete user"
+msgstr ""
+
+#: PodcastGenerator/admin/podcast_details.php:46
+msgid "Change Podcast Details"
+msgstr ""
+
+#: PodcastGenerator/admin/podcast_details.php:48
+msgid "Podcast Title"
+msgstr ""
+
+#: PodcastGenerator/admin/podcast_details.php:50
+msgid "Podcast Subtitle or Slogan"
+msgstr ""
+
+#: PodcastGenerator/admin/podcast_details.php:52
+msgid "Podcast Description"
+msgstr ""
+
+#: PodcastGenerator/admin/podcast_details.php:54
+msgid "Copyright Notice"
+msgstr ""
+
+#: PodcastGenerator/admin/podcast_details.php:58
+msgid "Author E-Mail Address"
+msgstr ""
+
+#: PodcastGenerator/admin/podcast_details.php:60
+msgid "Feed Language"
+msgstr ""
+
+#: PodcastGenerator/admin/podcast_details.php:60
+msgid "Main language of your podcast"
+msgstr ""
+
+#: PodcastGenerator/admin/podcast_details.php:136
+msgid "Explicit Podcast"
+msgstr ""
+
+#: PodcastGenerator/admin/store_cat.php:17
+msgid "Category 1 needs to be set"
+msgstr ""
+
+#: PodcastGenerator/admin/store_cat.php:34
+msgid "Select Podcast Category"
+msgstr ""
+
+#: PodcastGenerator/admin/store_cat.php:48
+msgid "Select Podcast Categories"
+msgstr ""
+
+#: PodcastGenerator/admin/store_cat.php:49
+msgid "Select or change Podcast Categories (for iTunes)"
+msgstr ""
+
+#: PodcastGenerator/admin/store_cat.php:105
+#: PodcastGenerator/admin/theme_freebox.php:75
+msgid "Save"
+msgstr ""
+
+#: PodcastGenerator/admin/store_cover.php:16
+msgid "Image is not a JPEG"
+msgstr ""
+
+#: PodcastGenerator/admin/store_cover.php:23
+msgid "Image is not quadratic"
+msgstr ""
+
+#: PodcastGenerator/admin/store_cover.php:29
+msgid "File was not uploaded"
+msgstr ""
+
+#: PodcastGenerator/admin/store_cover.php:44
+msgid "Store Cover"
+msgstr ""
+
+#: PodcastGenerator/admin/store_cover.php:58
+msgid "Change Cover"
+msgstr ""
+
+#: PodcastGenerator/admin/store_cover.php:59
+msgid "The cover art will be displayed in the podcast readers."
+msgstr ""
+
+#: PodcastGenerator/admin/store_cover.php:65
+msgid "Current Cover"
+msgstr ""
+
+#: PodcastGenerator/admin/store_cover.php:68
+msgid "Upload new cover"
+msgstr ""
+
+#: PodcastGenerator/admin/store_cover.php:70
+msgid "Select file"
+msgstr ""
+
+#: PodcastGenerator/admin/store_cover.php:72
+msgid "Upload"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_buttons.php:24
+msgid "Item exists"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_buttons.php:29
+msgid "Name, Link and CSS Class needs to be set"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_buttons.php:84
+msgid "Theme Buttons"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_buttons.php:99
+msgid "Click on the button you wish to edit"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_buttons.php:119
+#: PodcastGenerator/admin/theme_buttons.php:140
+msgid "Name (needs to be unique)"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_buttons.php:121
+#: PodcastGenerator/admin/theme_buttons.php:142
+msgid "Link (where it should point to)"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_buttons.php:123
+#: PodcastGenerator/admin/theme_buttons.php:144
+#, php-format
+msgid "CSS Classes (depends on theme, you can use %s in the default theme)"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_buttons.php:125
+#: PodcastGenerator/admin/theme_buttons.php:146
+msgid "Protocol (Leave it blank if you don't know what you are doing)"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_buttons.php:130
+msgid "Delete Button"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_buttons.php:138
+msgid "Add Button"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_change.php:45
+msgid "Theme Change"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_change.php:59
+msgid "Change theme"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_change.php:60
+#, php-format
+msgid "You can upload themes to your %s folder"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_change.php:61
+msgid "Installed themes"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_change.php:65
+msgid "No compatible themes installed"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_change.php:81
+msgid "This theme is currently in use"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_change.php:83
+msgid "Switch theme"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_freebox.php:34
+#: PodcastGenerator/admin/theme_freebox.php:48
+msgid "Customize Freebox"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_freebox.php:52
+msgid "Current Freebox"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_freebox.php:60
+msgid "Enable / Disable Freebox"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_freebox.php:65
+msgid "Disable Freebox"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_freebox.php:72
+msgid "Change Freebox content"
+msgstr ""
+
+#: PodcastGenerator/admin/theme_freebox.php:73
+msgid "Content"
+msgstr ""
+
+#: PodcastGenerator/auth.php:14
+msgid "This Podcast has no password"
+msgstr ""
+
+#: PodcastGenerator/auth.php:18
+msgid "Already signed in"
+msgstr ""
+
+#: PodcastGenerator/auth.php:24
+msgid "Success"
+msgstr ""
+
+#: PodcastGenerator/auth.php:27
+msgid "Invalid password"
+msgstr ""
+
+#: PodcastGenerator/auth.php:38 PodcastGenerator/auth.php:44
+msgid "Password required"
+msgstr ""
+
+#: PodcastGenerator/auth.php:51
+msgid "Enter Password"
+msgstr ""
+
+#: PodcastGenerator/auth.php:53
+msgid "Login"
+msgstr ""
+
+#: PodcastGenerator/categories.php:21 PodcastGenerator/feed.php:15
+#: PodcastGenerator/index.php:16
+msgid "Authentication required"
+msgstr ""
+
+#: PodcastGenerator/categories.php:37 PodcastGenerator/index.php:52
+msgid "More"
+msgstr ""
+
+#: PodcastGenerator/categories.php:38 PodcastGenerator/index.php:53
+msgid "Download"
+msgstr ""
+
+#: PodcastGenerator/categories.php:39 PodcastGenerator/index.php:54
+msgid "Edit/Delete (Admin)"
+msgstr ""
+
+#: PodcastGenerator/categories.php:40 PodcastGenerator/index.php:65
+msgid "Categories"
+msgstr ""
+
+#: PodcastGenerator/index.php:55
+msgid "Filetype"
+msgstr ""
+
+#: PodcastGenerator/index.php:56
+msgid "Size"
+msgstr ""
+
+#: PodcastGenerator/index.php:57
+msgid "Duration"
+msgstr ""
+
+#: PodcastGenerator/index.php:61
+msgid "No episodes uploaded yet"
+msgstr ""

--- a/PodcastGenerator/components/locale/fr_FR/LC_MESSAGES/messages.po
+++ b/PodcastGenerator/components/locale/fr_FR/LC_MESSAGES/messages.po
@@ -1,110 +1,121 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR The Podcast Generator Translation Team
+# French translation of Podcast Generator.
+# Copyright (C) 2021 The Podcast Generator Translation Team
 # This file is distributed under the same license as the Podcast Generator package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Emmanuel Gil Peyrot <linkmauve@linkmauve.fr>, 2021.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Podcast Generator \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-05-30 11:39+0200\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2021-05-13 17:34+0200\n"
+"Last-Translator: Emmanuel Gil Peyrot <linkmauve@linkmauve.fr>\n"
+"Language-Team: French - France <gnomefr@traduc.org>\n"
+"Language: fr_FR\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1)\n"
+"X-Generator: Gtranslator 40.0\n"
 
 #: PodcastGenerator/admin/episodes_bulk.php:37
 #: PodcastGenerator/admin/navbar.php:20
 msgid "Bulk download episodes"
-msgstr ""
+msgstr "Télécharger des épisodes en masse"
 
 #: PodcastGenerator/admin/episodes_bulk.php:50
 msgid ""
 "If you want to bulk download all episodes, you need to have curl installed.\n"
-"        On Windows 10, macOS and most Linux distributions it is already pre-installed. Please\n"
-"        open your Terminal app on macOS and Linux or open the start menu and search for cmd.exe on Windows.\n"
-"        After this paste the following (long) command into the terminal/cmd.exe and press enter."
+"        On Windows 10, macOS and most Linux distributions it is already pre-"
+"installed. Please\n"
+"        open your Terminal app on macOS and Linux or open the start menu and "
+"search for cmd.exe on Windows.\n"
+"        After this paste the following (long) command into the terminal/cmd."
+"exe and press enter."
 msgstr ""
+"Si vous voulez télécharger des épisodes en masse, vous devez avoir curl "
+"installé.\n"
+"        Sur Windows 10, macOS et la plupart des distributions Linux il est "
+"déjà pré-installé. Veuillez ouvrir votre application terminal sur macOS et "
+"Linux, ou ouvrir le menu démarrer et chercher cmd.exe sur Windows.\n"
+"        Après ça, collez la (longue) commande suivante dans le terminal/cmd."
+"exe et appuyez sur entrée."
 
 #: PodcastGenerator/admin/episodes_edit.php:14
 msgid "No name given"
-msgstr ""
+msgstr "Aucun nom donné"
 
 #: PodcastGenerator/admin/episodes_edit.php:17
 msgid "Episode does not exist"
-msgstr ""
+msgstr "L’épisode n’existe pas"
 
 #: PodcastGenerator/admin/episodes_edit.php:42
 #: PodcastGenerator/admin/episodes_upload.php:15
 msgid "Empty title"
-msgstr ""
+msgstr "Titre vide"
 
 #: PodcastGenerator/admin/episodes_edit.php:46
 #: PodcastGenerator/admin/episodes_upload.php:19
 msgid "Empty Short Description"
-msgstr ""
+msgstr "Description courte vide"
 
 #: PodcastGenerator/admin/episodes_edit.php:50
 #: PodcastGenerator/admin/episodes_upload.php:23
 msgid "Empty Date"
-msgstr ""
+msgstr "Date vide"
 
 #: PodcastGenerator/admin/episodes_edit.php:54
 #: PodcastGenerator/admin/episodes_upload.php:27
 msgid "Empty explicit value"
-msgstr ""
+msgstr "Valeur explicite vide"
 
 #: PodcastGenerator/admin/episodes_edit.php:58
 #: PodcastGenerator/admin/episodes_upload.php:31
 msgid "Empty author name"
-msgstr ""
+msgstr "Nom d’auteur vide"
 
 #: PodcastGenerator/admin/episodes_edit.php:62
 #: PodcastGenerator/admin/episodes_upload.php:35
 msgid "Empty author email"
-msgstr ""
+msgstr "Adresse mail de l’auteur vide"
 
 #: PodcastGenerator/admin/episodes_edit.php:73
 #: PodcastGenerator/admin/episodes_upload.php:46
 msgid "Too many categories selected (max: 3)"
-msgstr ""
+msgstr "Trop de catégories sélectionnées (maximum : 3)"
 
 #: PodcastGenerator/admin/episodes_edit.php:80
 #: PodcastGenerator/admin/episodes_upload.php:60
 msgid "Invalid Author E-Mail provided"
-msgstr ""
+msgstr "Adresse mail de l’auteur invalide"
 
 #: PodcastGenerator/admin/episodes_edit.php:86
 #: PodcastGenerator/admin/episodes_upload.php:66
 msgid "Size of the 'Short Description' exceeded"
-msgstr ""
+msgstr "Taile de la description courte trop longue"
 
 #: PodcastGenerator/admin/episodes_edit.php:152
 #: PodcastGenerator/admin/episodes_edit.php:166
 msgid "Edit Episode"
-msgstr ""
+msgstr "Éditer l’épisode"
 
 #: PodcastGenerator/admin/episodes_edit.php:174
 msgid "Main Information"
-msgstr ""
+msgstr "Informations principales"
 
 #: PodcastGenerator/admin/episodes_edit.php:177
 #: PodcastGenerator/admin/episodes_upload.php:222
 msgid "Title"
-msgstr ""
+msgstr "Titre"
 
 #: PodcastGenerator/admin/episodes_edit.php:181
 #: PodcastGenerator/admin/episodes_upload.php:226
 msgid "Short Description"
-msgstr ""
+msgstr "Description courte"
 
 #: PodcastGenerator/admin/episodes_edit.php:183
 msgid " characters remaining"
-msgstr ""
+msgstr " caractères restants"
 
 #: PodcastGenerator/admin/episodes_edit.php:186
 #: PodcastGenerator/admin/episodes_upload.php:231
@@ -112,182 +123,184 @@ msgstr ""
 #: PodcastGenerator/admin/store_cat.php:69
 #: PodcastGenerator/admin/store_cat.php:87
 msgid "Category"
-msgstr ""
+msgstr "Catégorie"
 
 #: PodcastGenerator/admin/episodes_edit.php:187
 #: PodcastGenerator/admin/episodes_upload.php:232
 msgid "You can select up to 3 categories"
-msgstr ""
+msgstr "Vous pouvez sélectionner jusqu’à trois catégories"
 
 #: PodcastGenerator/admin/episodes_edit.php:204
 #: PodcastGenerator/admin/episodes_upload.php:243
 msgid "Publication Date"
-msgstr ""
+msgstr "Date de publication"
 
 #: PodcastGenerator/admin/episodes_edit.php:205
 #: PodcastGenerator/admin/episodes_upload.php:244
 msgid "If you select a date in the future, it will be published then"
-msgstr ""
+msgstr "Si vous donnez une date dans le futur, il sera publié à ce moment là"
 
 #: PodcastGenerator/admin/episodes_edit.php:206
 #: PodcastGenerator/admin/episodes_upload.php:245
 msgid "Date"
-msgstr ""
+msgstr "Date"
 
 #: PodcastGenerator/admin/episodes_edit.php:208
 #: PodcastGenerator/admin/episodes_upload.php:247
 msgid "Time"
-msgstr ""
+msgstr "Heure"
 
 #: PodcastGenerator/admin/episodes_edit.php:213
 msgid "Extra Information"
-msgstr ""
+msgstr "Informations additionnelles"
 
 #: PodcastGenerator/admin/episodes_edit.php:216
 #: PodcastGenerator/admin/episodes_upload.php:255
 msgid "Long Description"
-msgstr ""
+msgstr "Description longue"
 
 #: PodcastGenerator/admin/episodes_edit.php:220
 #: PodcastGenerator/admin/episodes_upload.php:259
 msgid "iTunes Keywords"
-msgstr ""
+msgstr "Mots-clés iTunes"
 
 #: PodcastGenerator/admin/episodes_edit.php:224
 msgid "Explicit Content"
-msgstr ""
+msgstr "Contenu explicite"
 
 #: PodcastGenerator/admin/episodes_edit.php:228
 #: PodcastGenerator/admin/episodes_upload.php:267
 msgid "Author"
-msgstr ""
+msgstr "Auteur"
 
 #: PodcastGenerator/admin/episodes_edit.php:232
 msgid "Save Changes"
-msgstr ""
+msgstr "Enregistrer les changements"
 
 #: PodcastGenerator/admin/episodes_edit.php:237
 msgid "Delete Episode"
-msgstr ""
+msgstr "Supprimer l’épisode"
 
 #: PodcastGenerator/admin/episodes_edit.php:244
 msgid "\" characters remaining\""
-msgstr ""
+msgstr "« caractères restants »"
 
 #: PodcastGenerator/admin/episodes_ftp_feature.php:139
 #, php-format
 msgid "Added %d new episode(s)"
-msgstr ""
+msgstr "%d nouveaux épisodes ajoutés"
 
 #: PodcastGenerator/admin/episodes_ftp_feature.php:141
 msgid "No new episodes were found"
-msgstr ""
+msgstr "Aucun nouvel épisode n’a été trouvé"
 
 #: PodcastGenerator/admin/episodes_ftp_feature.php:149
 msgid "FTP Feature"
-msgstr ""
+msgstr "Fonctionnalité FTP"
 
 #: PodcastGenerator/admin/episodes_ftp_feature.php:163
 msgid "FTP Auto Indexing"
-msgstr ""
+msgstr "Indexation automatique FTP"
 
 #: PodcastGenerator/admin/episodes_ftp_feature.php:166
 msgid "Begin"
-msgstr ""
+msgstr "Commencer"
 
 #: PodcastGenerator/admin/episodes_manage_cats.php:40
 msgid "Category already exists"
-msgstr ""
+msgstr "Catégorie existe déjà"
 
 #: PodcastGenerator/admin/episodes_manage_cats.php:62
 #: PodcastGenerator/admin/episodes_manage_cats.php:76
 #: PodcastGenerator/admin/navbar.php:18
 msgid "Manage categories"
-msgstr ""
+msgstr "Gérer les catégories"
 
 #: PodcastGenerator/admin/episodes_manage_cats.php:77
 msgid "Add category"
-msgstr ""
+msgstr "Ajouter une catégorie"
 
 #: PodcastGenerator/admin/episodes_manage_cats.php:79
 #: PodcastGenerator/admin/episodes_manage_cats.php:80
 msgid "Category Name"
-msgstr ""
+msgstr "Nom de la catégorie"
 
 #: PodcastGenerator/admin/episodes_manage_cats.php:81
 msgid "Add"
-msgstr ""
+msgstr "Ajouter"
 
 #: PodcastGenerator/admin/episodes_manage_cats.php:83
 msgid "Current Categories"
-msgstr ""
+msgstr "Catégories courantes"
 
 #: PodcastGenerator/admin/episodes_manage_cats.php:88
 msgid "Delete"
-msgstr ""
+msgstr "Supprimer"
 
 #: PodcastGenerator/admin/episodes_regenerate.php:19
 msgid "Regenerate Feed"
-msgstr ""
+msgstr "Régénérer le flux"
 
 #: PodcastGenerator/admin/episodes_regenerate.php:33
 msgid "Successfully regenerated RSS feed"
-msgstr ""
+msgstr "Flux RSS régénéré avec succès"
 
 #: PodcastGenerator/admin/episodes_regenerate.php:34
 msgid "Return"
-msgstr ""
+msgstr "Revenir"
 
 #: PodcastGenerator/admin/episodes_upload.php:73
 msgid "Invalid filename, only A-Z, a-z, underscores and dots are permitted"
 msgstr ""
+"Nom de fichier invalide, seuls A-Z, a-z, les underscores et les points sont "
+"acceptés"
 
 #: PodcastGenerator/admin/episodes_upload.php:100
 msgid "Invalid file extension"
-msgstr ""
+msgstr "Extension de fichier invalide"
 
 #: PodcastGenerator/admin/episodes_upload.php:105
 msgid "The file upload was not successfully"
-msgstr ""
+msgstr "L’envoi du fichier a échoué"
 
 #: PodcastGenerator/admin/episodes_upload.php:112
 msgid "The uploaded file is not readable (permission error)"
-msgstr ""
+msgstr "Le fichier envoyé n’est pas lisible (erreur de permission)"
 
 #: PodcastGenerator/admin/episodes_upload.php:125
 #, php-format
 msgid "Unsupported mime type detected for file with extension \"%s\""
-msgstr ""
+msgstr "Type MIME non-supporté détecté pour le fichier avec l’extension « %s »"
 
 #: PodcastGenerator/admin/episodes_upload.php:189
 #: PodcastGenerator/admin/episodes_upload.php:203
 msgid "Upload Episode"
-msgstr ""
+msgstr "Envoyer un épisode"
 
 #: PodcastGenerator/admin/episodes_upload.php:206
 msgid "uploaded successfully"
-msgstr ""
+msgstr "envoyé avec succès"
 
 #: PodcastGenerator/admin/episodes_upload.php:215
 msgid "Main Informations"
-msgstr ""
+msgstr "Informations principales"
 
 #: PodcastGenerator/admin/episodes_upload.php:218
 msgid "File"
-msgstr ""
+msgstr "Fichier"
 
 #: PodcastGenerator/admin/episodes_upload.php:228
 #: PodcastGenerator/admin/episodes_upload.php:280
 msgid "characters remaining"
-msgstr ""
+msgstr "caractères restants"
 
 #: PodcastGenerator/admin/episodes_upload.php:252
 msgid "Extra Informations"
-msgstr ""
+msgstr "Informations supplémentaires"
 
 #: PodcastGenerator/admin/episodes_upload.php:263
 msgid "Explicit content"
-msgstr ""
+msgstr "Contenu explicite"
 
 #: PodcastGenerator/admin/episodes_upload.php:264
 #: PodcastGenerator/admin/pg_config.php:43
@@ -295,7 +308,7 @@ msgstr ""
 #: PodcastGenerator/admin/pg_config.php:51
 #: PodcastGenerator/admin/podcast_details.php:137
 msgid "Yes"
-msgstr ""
+msgstr "Oui"
 
 #: PodcastGenerator/admin/episodes_upload.php:264
 #: PodcastGenerator/admin/pg_config.php:43
@@ -303,202 +316,232 @@ msgstr ""
 #: PodcastGenerator/admin/pg_config.php:51
 #: PodcastGenerator/admin/podcast_details.php:137
 msgid "No"
-msgstr ""
+msgstr "Non"
 
 #: PodcastGenerator/admin/episodes_upload.php:268
 #: PodcastGenerator/admin/podcast_details.php:56
 msgid "Author Name"
-msgstr ""
+msgstr "Nom de l’auteur"
 
 #: PodcastGenerator/admin/episodes_upload.php:269
 msgid "Author E-Mail"
-msgstr ""
+msgstr "Adresse mail de l’auteur"
 
 #: PodcastGenerator/admin/episodes_upload.php:271
 msgid "Upload episode"
-msgstr ""
+msgstr "Envoyer un épisode"
 
 #: PodcastGenerator/admin/forgot.php:4
 msgid "Password Reset"
-msgstr ""
+msgstr "Réinitialiser le mot de passe"
 
 #: PodcastGenerator/admin/forgot.php:12
 msgid "Reset your password"
-msgstr ""
+msgstr "Réinitialiser votre mot de passe"
 
 #: PodcastGenerator/admin/forgot.php:13
 msgid "No password, no problem!"
-msgstr ""
+msgstr "Pas de mot de passe, pas de problème !"
 
 #: PodcastGenerator/admin/forgot.php:16
-msgid "We offer a tool which allows you to easily recover your password. However, the danger of this is that as long as this file is online, anyone can reset this password so this file shouldn't be online that long."
+msgid ""
+"We offer a tool which allows you to easily recover your password. However, "
+"the danger of this is that as long as this file is online, anyone can reset "
+"this password so this file shouldn't be online that long."
 msgstr ""
+"Nous offrons un outil qui vous permet de récupérer votre mot de passe "
+"facilement. Cependant, tant que ce fichier est en ligne n’importe qui peut "
+"réinitialiser le mot de passe, donc évitez de le garder en ligne plus "
+"longtemps que nécessaire !"
 
 #: PodcastGenerator/admin/forgot.php:18
 #, php-format
-msgid "In the ZIP file of this version which you downloaded there is a file in the %s folder called %s. Upload this file to into the admin directory with the name %s"
+msgid ""
+"In the ZIP file of this version which you downloaded there is a file in the "
+"%s folder called %s. Upload this file to into the admin directory with the "
+"name %s"
 msgstr ""
+"Dans le fichier zip de la version que vous avez téléchargée, il existe un "
+"fichier dans le dossier %s nommé %s. Envoyez ce fichier dans le dossier "
+"admin avec le nom %s"
 
 #: PodcastGenerator/admin/forgot.php:19
-msgid "If you no don't have this ZIP file anymore, don't worry! All versions of Podcast Generator ever released since 2.5 are available on the Podcast Generator Homepage."
+msgid ""
+"If you no don't have this ZIP file anymore, don't worry! All versions of "
+"Podcast Generator ever released since 2.5 are available on the Podcast "
+"Generator Homepage."
 msgstr ""
+"Si vous n’avez plus ce fichier zip, pas de panique ! Toutes les versions de "
+"Podcast Generator sorties depuis la 2.5 sont disponibles sur le site web de "
+"Podcast Generator."
 
 #: PodcastGenerator/admin/index.php:37
 msgid "Welcome to your Podcast Generator Admin Interface"
-msgstr ""
+msgstr "Bienvenue dans votre interface d’administration de Podcast Generator"
 
 #: PodcastGenerator/admin/login.php:24
 msgid "Login disabled for security reasons"
-msgstr ""
+msgstr "Connexion désactivée pour des raisons de sécurité"
 
 #: PodcastGenerator/admin/login.php:29 PodcastGenerator/admin/pg_users.php:49
 msgid "Missing fields"
-msgstr ""
+msgstr "Champs manquants"
 
 #: PodcastGenerator/admin/login.php:37
 msgid "Invalid username or password"
-msgstr ""
+msgstr "Nom d’utilisateur ou mot de passe invalide"
 
 #: PodcastGenerator/admin/login.php:62 PodcastGenerator/admin/pg_users.php:99
 #: PodcastGenerator/admin/pg_users.php:116
 msgid "Username"
-msgstr ""
+msgstr "Nom d’utilisateur"
 
 #: PodcastGenerator/admin/login.php:64 PodcastGenerator/admin/pg_users.php:101
 msgid "Password"
-msgstr ""
+msgstr "Mot de passe"
 
 #: PodcastGenerator/admin/login.php:66
 msgid "Forgot Password?"
-msgstr ""
+msgstr "Mot de passe oublié ?"
 
 #: PodcastGenerator/admin/login.php:68
 msgid "Sign In"
-msgstr ""
+msgstr "Se connecter"
 
 #: PodcastGenerator/admin/navbar.php:3
 msgid "Toggle navigation"
-msgstr ""
+msgstr "Activer/désactiver la navigation"
 
 #: PodcastGenerator/admin/navbar.php:13
 msgid "Episodes"
-msgstr ""
+msgstr "Épisodes"
 
 #: PodcastGenerator/admin/navbar.php:16
 msgid "Upload New Episodes"
-msgstr ""
+msgstr "Envoyer de nouveaux épisodes"
 
 #: PodcastGenerator/admin/navbar.php:17
 msgid "Edit / Delete Episode"
-msgstr ""
+msgstr "Modifier/supprimer un épisode"
 
 #: PodcastGenerator/admin/navbar.php:19
 msgid "FTP Feature (Auto Indexing)"
-msgstr ""
+msgstr "Fonctionnalité FTP (indexation automatique)"
 
 #: PodcastGenerator/admin/navbar.php:21
 msgid "Manually regenerate RSS feed"
-msgstr ""
+msgstr "Régénérer manuellement le flux RSS"
 
 #: PodcastGenerator/admin/navbar.php:26
 msgid "Themes and aspect"
-msgstr ""
+msgstr "Thèmes et aspect"
 
 #: PodcastGenerator/admin/navbar.php:29
 msgid "Change Theme"
-msgstr ""
+msgstr "Changer le thème"
 
 #: PodcastGenerator/admin/navbar.php:30
 msgid "Customize your Freebox"
-msgstr ""
+msgstr "Modifier votre boîte libre"
 
 #: PodcastGenerator/admin/navbar.php:31
 #: PodcastGenerator/admin/theme_buttons.php:98
 msgid "Change Buttons"
-msgstr ""
+msgstr "Changer les boutons"
 
 #: PodcastGenerator/admin/navbar.php:36
 msgid "Podcast Platform Settings"
-msgstr ""
+msgstr "Paramètres de la plateforme de podcast"
 
 #: PodcastGenerator/admin/navbar.php:39
 msgid "Change Cover Art"
-msgstr ""
+msgstr "Changer la pochette"
 
 #: PodcastGenerator/admin/navbar.php:40
 msgid "Change Podcast Category"
-msgstr ""
+msgstr "Changer la catégorie du podcast"
 
 #: PodcastGenerator/admin/navbar.php:45
 #: PodcastGenerator/admin/podcast_details.php:27
 msgid "Podcast Details"
-msgstr ""
+msgstr "Détails du podcast"
 
 #: PodcastGenerator/admin/navbar.php:48
 msgid "Change Podcast details"
-msgstr ""
+msgstr "Changer les détails du podcast"
 
 #: PodcastGenerator/admin/navbar.php:53
 msgid "Podcast Generator"
-msgstr ""
+msgstr "Podcast Generator"
 
 #: PodcastGenerator/admin/navbar.php:56
 msgid "Change Podcast Generator Config"
-msgstr ""
+msgstr "Changer la configuration de Podcast Generator"
 
 #: PodcastGenerator/admin/navbar.php:57 PodcastGenerator/admin/pg_users.php:64
 #: PodcastGenerator/admin/pg_users.php:78
 msgid "Manage users"
-msgstr ""
+msgstr "Gérer les utilisateurs"
 
 #: PodcastGenerator/admin/navbar.php:63
 msgid "View Podcast"
-msgstr ""
+msgstr "Voir le podcast"
 
 #: PodcastGenerator/admin/pg_config.php:25
 msgid "Podcast Generator Configuration"
-msgstr ""
+msgstr "Configuration de Podcast Generator"
 
 #: PodcastGenerator/admin/pg_config.php:39
 msgid "Change Podcast Generator Configuration"
-msgstr ""
+msgstr "Changer la configuration de Podcast Generator"
 
 #: PodcastGenerator/admin/pg_config.php:41
 msgid "Enable Audio and Video Player"
-msgstr ""
+msgstr "Activer le lecteur audio et vidéo"
 
 #: PodcastGenerator/admin/pg_config.php:42
 msgid "Enable streaming in web browser"
-msgstr ""
+msgstr "Activer le streaming dans le navigateur web"
 
 #: PodcastGenerator/admin/pg_config.php:45
 #: PodcastGenerator/admin/theme_freebox.php:63
 msgid "Enable Freebox"
-msgstr ""
+msgstr "Activer la freebox"
 
 #: PodcastGenerator/admin/pg_config.php:46
-msgid "Freebox allows you to write freely what you wish, add links or text through a visual editor in the admin section."
+msgid ""
+"Freebox allows you to write freely what you wish, add links or text through "
+"a visual editor in the admin section."
 msgstr ""
+"La freebox vous permet d’écrire ce que vous souhaitez, ajouter des liens ou "
+"du texte grâce à un éditeur visuel, dans la section d’administration."
 
 #: PodcastGenerator/admin/pg_config.php:49
 msgid "Enable categories"
-msgstr ""
+msgstr "Activer les catégories"
 
 #: PodcastGenerator/admin/pg_config.php:50
 msgid "Enable categories feature to make thematic lists of your podcasts."
 msgstr ""
+"Activez la fonctionnalités catégories pour créer des listes thématiques de "
+"vos podcasts"
 
 #: PodcastGenerator/admin/pg_config.php:53
 msgid "Use cron to regenerate the RSS feed"
-msgstr ""
+msgstr "Utiliser cron pour régénérer le flux RSS"
 
 #: PodcastGenerator/admin/pg_config.php:56
 msgid "Password Protection for the web pages"
-msgstr ""
+msgstr "Protection par mot de passe pour les pages web"
 
 #: PodcastGenerator/admin/pg_config.php:57
-msgid "Leave empty for no password, keep in mind that the feed and the audio files will still be accessible no matter if a password is set or not"
+msgid ""
+"Leave empty for no password, keep in mind that the feed and the audio files "
+"will still be accessible no matter if a password is set or not"
 msgstr ""
+"Laissez vide pour ne pas mettre de mot de passe. N’oubliez pas que le flux "
+"et les fichiers audio resteront accessibles qu’un mot de passe soit défini "
+"ou pas"
 
 #: PodcastGenerator/admin/pg_config.php:60
 #: PodcastGenerator/admin/pg_users.php:104
@@ -506,334 +549,337 @@ msgstr ""
 #: PodcastGenerator/admin/theme_buttons.php:127
 #: PodcastGenerator/admin/theme_buttons.php:148
 msgid "Submit"
-msgstr ""
+msgstr "Envoyer"
 
 #: PodcastGenerator/admin/pg_users.php:18
 msgid "Error while changing password"
-msgstr ""
+msgstr "Erreur en changeant le mot de passe"
 
 #: PodcastGenerator/admin/pg_users.php:30
 #: PodcastGenerator/admin/pg_users.php:130
 msgid "You cannot delete yourself"
-msgstr ""
+msgstr "Vous ne pouvez pas vous supprimer vous-même"
 
 #: PodcastGenerator/admin/pg_users.php:35
 msgid "User does not exists"
-msgstr ""
+msgstr "L’utilisateur n’existe pas"
 
 #: PodcastGenerator/admin/pg_users.php:39
 msgid "Unknown error while deleting user"
-msgstr ""
+msgstr "Erreur inconnue en supprimant l’utilisateur"
 
 #: PodcastGenerator/admin/pg_users.php:53
 msgid "Error while creating user"
-msgstr ""
+msgstr "Erreur en créant l’utilisateur"
 
 #: PodcastGenerator/admin/pg_users.php:79
 msgid "It may take a few seconds until the changes are visible"
 msgstr ""
+"Ça peut prendre quelques secondes pour que les changements soient visibles"
 
 #: PodcastGenerator/admin/pg_users.php:82
 msgid "User changed successfully"
-msgstr ""
+msgstr "Utilisateur modifié avec succès"
 
 #: PodcastGenerator/admin/pg_users.php:84
 msgid "User created successfully"
-msgstr ""
+msgstr "Utilisateur créé avec succès"
 
 #: PodcastGenerator/admin/pg_users.php:86
 msgid "User deleted successfully"
-msgstr ""
+msgstr "Utilisateur supprimé avec succès"
 
 #: PodcastGenerator/admin/pg_users.php:90
 msgid "List of users"
-msgstr ""
+msgstr "Liste des utilisateurs"
 
 #: PodcastGenerator/admin/pg_users.php:97
 msgid "Create User"
-msgstr ""
+msgstr "Créer un utilisateur"
 
 #: PodcastGenerator/admin/pg_users.php:111
 msgid "User does not exist"
-msgstr ""
+msgstr "L’utilisateur n’existe pas"
 
 #: PodcastGenerator/admin/pg_users.php:117
 msgid "You cannot edit usernames"
-msgstr ""
+msgstr "Vous ne pouvez pas éditer les noms d’utilisateurs"
 
 #: PodcastGenerator/admin/pg_users.php:118
 msgid "New Password"
-msgstr ""
+msgstr "Nouveau mot de passe"
 
 #: PodcastGenerator/admin/pg_users.php:120
 msgid "Repeat new password"
-msgstr ""
+msgstr "Confirmation du nouveau mot de passe"
 
 #: PodcastGenerator/admin/pg_users.php:123
 msgid "Change"
-msgstr ""
+msgstr "Modifier"
 
 #: PodcastGenerator/admin/pg_users.php:126
 msgid "Delete user"
-msgstr ""
+msgstr "Supprimer l’utilisateur"
 
 #: PodcastGenerator/admin/podcast_details.php:46
 msgid "Change Podcast Details"
-msgstr ""
+msgstr "Modifier les détails du podcast"
 
 #: PodcastGenerator/admin/podcast_details.php:48
 msgid "Podcast Title"
-msgstr ""
+msgstr "Titre du podcast"
 
 #: PodcastGenerator/admin/podcast_details.php:50
 msgid "Podcast Subtitle or Slogan"
-msgstr ""
+msgstr "Sous-titre ou slogan du podcast"
 
 #: PodcastGenerator/admin/podcast_details.php:52
 msgid "Podcast Description"
-msgstr ""
+msgstr "Description du podcast"
 
 #: PodcastGenerator/admin/podcast_details.php:54
 msgid "Copyright Notice"
-msgstr ""
+msgstr "Information de droit d’auteur"
 
 #: PodcastGenerator/admin/podcast_details.php:58
 msgid "Author E-Mail Address"
-msgstr ""
+msgstr "Adresse mail de l’auteur"
 
 #: PodcastGenerator/admin/podcast_details.php:60
 msgid "Feed Language"
-msgstr ""
+msgstr "Langue du flux"
 
 #: PodcastGenerator/admin/podcast_details.php:60
 msgid "Main language of your podcast"
-msgstr ""
+msgstr "Langue principale de votre podcast"
 
 #: PodcastGenerator/admin/podcast_details.php:136
 msgid "Explicit Podcast"
-msgstr ""
+msgstr "Podcast explicite"
 
 #: PodcastGenerator/admin/store_cat.php:17
 msgid "Category 1 needs to be set"
-msgstr ""
+msgstr "La première catégorie doit être définie"
 
 #: PodcastGenerator/admin/store_cat.php:34
 msgid "Select Podcast Category"
-msgstr ""
+msgstr "Sélectionner la catégorie du podcast"
 
 #: PodcastGenerator/admin/store_cat.php:48
 msgid "Select Podcast Categories"
-msgstr ""
+msgstr "Sélectionner les catégories du podcast"
 
 #: PodcastGenerator/admin/store_cat.php:49
 msgid "Select or change Podcast Categories (for iTunes)"
-msgstr ""
+msgstr "Sélectionner ou changer les catégories du podcast (pour iTunes)"
 
 #: PodcastGenerator/admin/store_cat.php:105
 #: PodcastGenerator/admin/theme_freebox.php:75
 msgid "Save"
-msgstr ""
+msgstr "Enregistrer"
 
 #: PodcastGenerator/admin/store_cover.php:16
 msgid "Image is not a JPEG"
-msgstr ""
+msgstr "L’image n’est pas un JPEG"
 
 #: PodcastGenerator/admin/store_cover.php:23
 msgid "Image is not quadratic"
-msgstr ""
+msgstr "L’image n’est pas quadratique"
 
 #: PodcastGenerator/admin/store_cover.php:29
 msgid "File was not uploaded"
-msgstr ""
+msgstr "Le fichier n’a pas été envoyé"
 
 #: PodcastGenerator/admin/store_cover.php:44
 msgid "Store Cover"
-msgstr ""
+msgstr "Stocker la pochette"
 
 #: PodcastGenerator/admin/store_cover.php:58
 msgid "Change Cover"
-msgstr ""
+msgstr "Changer la pochette"
 
 #: PodcastGenerator/admin/store_cover.php:59
 msgid "The cover art will be displayed in the podcast readers."
-msgstr ""
+msgstr "La pochette sera affichée dans les lecteurs de podcasts."
 
 #: PodcastGenerator/admin/store_cover.php:65
 msgid "Current Cover"
-msgstr ""
+msgstr "Pochette courante"
 
 #: PodcastGenerator/admin/store_cover.php:68
 msgid "Upload new cover"
-msgstr ""
+msgstr "Envoyer une nouvelle pochette"
 
 #: PodcastGenerator/admin/store_cover.php:70
 msgid "Select file"
-msgstr ""
+msgstr "Sélectionner un fichier"
 
 #: PodcastGenerator/admin/store_cover.php:72
 msgid "Upload"
-msgstr ""
+msgstr "Envoyer"
 
 #: PodcastGenerator/admin/theme_buttons.php:24
 msgid "Item exists"
-msgstr ""
+msgstr "L’élément existe déjà"
 
 #: PodcastGenerator/admin/theme_buttons.php:29
 msgid "Name, Link and CSS Class needs to be set"
-msgstr ""
+msgstr "Le nom, le lien et la classe CSS doivent être définis"
 
 #: PodcastGenerator/admin/theme_buttons.php:84
 msgid "Theme Buttons"
-msgstr ""
+msgstr "Boutons du thème"
 
 #: PodcastGenerator/admin/theme_buttons.php:99
 msgid "Click on the button you wish to edit"
-msgstr ""
+msgstr "Cliquez sur le bouton que vous voulez éditer"
 
 #: PodcastGenerator/admin/theme_buttons.php:119
 #: PodcastGenerator/admin/theme_buttons.php:140
 msgid "Name (needs to be unique)"
-msgstr ""
+msgstr "Nom (doit être unique)"
 
 #: PodcastGenerator/admin/theme_buttons.php:121
 #: PodcastGenerator/admin/theme_buttons.php:142
 msgid "Link (where it should point to)"
-msgstr ""
+msgstr "Lien (vers quoi il va pointer)"
 
 #: PodcastGenerator/admin/theme_buttons.php:123
 #: PodcastGenerator/admin/theme_buttons.php:144
 #, php-format
 msgid "CSS Classes (depends on theme, you can use %s in the default theme)"
 msgstr ""
+"Classes CSS (dépend du thème, vous pouvez utiliser %s dans le thème par "
+"défaut)"
 
 #: PodcastGenerator/admin/theme_buttons.php:125
 #: PodcastGenerator/admin/theme_buttons.php:146
 msgid "Protocol (Leave it blank if you don't know what you are doing)"
-msgstr ""
+msgstr "Protocole (laissez vide si vous ne savez pas ce que vous faites)"
 
 #: PodcastGenerator/admin/theme_buttons.php:130
 msgid "Delete Button"
-msgstr ""
+msgstr "Supprimer le bouton"
 
 #: PodcastGenerator/admin/theme_buttons.php:138
 msgid "Add Button"
-msgstr ""
+msgstr "Ajouter un bouton"
 
 #: PodcastGenerator/admin/theme_change.php:45
 msgid "Theme Change"
-msgstr ""
+msgstr "Changer de thème"
 
 #: PodcastGenerator/admin/theme_change.php:59
 msgid "Change theme"
-msgstr ""
+msgstr "Changer le thème"
 
 #: PodcastGenerator/admin/theme_change.php:60
 #, php-format
 msgid "You can upload themes to your %s folder"
-msgstr ""
+msgstr "Vous pouvez envoyer des thèmes dans votre dossier %s"
 
 #: PodcastGenerator/admin/theme_change.php:61
 msgid "Installed themes"
-msgstr ""
+msgstr "Thèmes installés"
 
 #: PodcastGenerator/admin/theme_change.php:65
 msgid "No compatible themes installed"
-msgstr ""
+msgstr "Aucun thème compatible installé"
 
 #: PodcastGenerator/admin/theme_change.php:81
 msgid "This theme is currently in use"
-msgstr ""
+msgstr "Ce thème est déjà en utilisation"
 
 #: PodcastGenerator/admin/theme_change.php:83
 msgid "Switch theme"
-msgstr ""
+msgstr "Changer de thème"
 
 #: PodcastGenerator/admin/theme_freebox.php:34
 #: PodcastGenerator/admin/theme_freebox.php:48
 msgid "Customize Freebox"
-msgstr ""
+msgstr "Modifier la boîte libre"
 
 #: PodcastGenerator/admin/theme_freebox.php:52
 msgid "Current Freebox"
-msgstr ""
+msgstr "Boîte libre courante"
 
 #: PodcastGenerator/admin/theme_freebox.php:60
 msgid "Enable / Disable Freebox"
-msgstr ""
+msgstr "Activer/désactiver la boîte libre"
 
 #: PodcastGenerator/admin/theme_freebox.php:65
 msgid "Disable Freebox"
-msgstr ""
+msgstr "Désactiver la boîte libre"
 
 #: PodcastGenerator/admin/theme_freebox.php:72
 msgid "Change Freebox content"
-msgstr ""
+msgstr "Changer le contenu de la boîte libre"
 
 #: PodcastGenerator/admin/theme_freebox.php:73
 msgid "Content"
-msgstr ""
+msgstr "Contenu"
 
 #: PodcastGenerator/auth.php:14
 msgid "This Podcast has no password"
-msgstr ""
+msgstr "Ce podcast n’a pas de mot de passe"
 
 #: PodcastGenerator/auth.php:18
 msgid "Already signed in"
-msgstr ""
+msgstr "Déjà connecté"
 
 #: PodcastGenerator/auth.php:24
 msgid "Success"
-msgstr ""
+msgstr "Succès"
 
 #: PodcastGenerator/auth.php:27
 msgid "Invalid password"
-msgstr ""
+msgstr "Mot de passe invalide"
 
 #: PodcastGenerator/auth.php:38 PodcastGenerator/auth.php:44
 msgid "Password required"
-msgstr ""
+msgstr "Mot de passe requis"
 
 #: PodcastGenerator/auth.php:51
 msgid "Enter Password"
-msgstr ""
+msgstr "Entrez votre mot de passe"
 
 #: PodcastGenerator/auth.php:53
 msgid "Login"
-msgstr ""
+msgstr "Se connecter"
 
 #: PodcastGenerator/categories.php:21 PodcastGenerator/feed.php:15
 #: PodcastGenerator/index.php:16
 msgid "Authentication required"
-msgstr ""
+msgstr "Identification requise"
 
 #: PodcastGenerator/categories.php:37 PodcastGenerator/index.php:52
 msgid "More"
-msgstr ""
+msgstr "Plus"
 
 #: PodcastGenerator/categories.php:38 PodcastGenerator/index.php:53
 msgid "Download"
-msgstr ""
+msgstr "Télécharger"
 
 #: PodcastGenerator/categories.php:39 PodcastGenerator/index.php:54
 msgid "Edit/Delete (Admin)"
-msgstr ""
+msgstr "Modifier/supprimer (administrateur)"
 
 #: PodcastGenerator/categories.php:40 PodcastGenerator/index.php:65
 msgid "Categories"
-msgstr ""
+msgstr "Catégories"
 
 #: PodcastGenerator/index.php:55
 msgid "Filetype"
-msgstr ""
+msgstr "Type de fichier"
 
 #: PodcastGenerator/index.php:56
 msgid "Size"
-msgstr ""
+msgstr "Taille"
 
 #: PodcastGenerator/index.php:57
 msgid "Duration"
-msgstr ""
+msgstr "Durée"
 
 #: PodcastGenerator/index.php:61
 msgid "No episodes uploaded yet"
-msgstr ""
+msgstr "Aucun épisode envoyé pour l’instant"


### PR DESCRIPTION
<!-- Please check all checkboxes by putting a 'x' into it. Example: [x] -->

* [x] I am the author of this code or the code is public domain
* [x] I release this code into the public domain

This hasn’t been tested yet in situ, so there may be some noun/verb issues still, as I haven’t checked the location of every string.

There are a few cases where the original string is sub-optimal, for instance where it hardcodes a singular or plural instead of using gettext’s automated plural rule, or when it hardcodes a number, but those can be fixed later.

Edit: it may also be useful to replace strings like `Filetype` with `Filetype: %s`, so that languages which don’t use this exact syntax can also be translated (in French we put a narrow non-breakable space before the colon for instance, while in Japanese we use a full-width colon “：” without a space afterwards).