### PR TITLE
Use sctrict comparison when checking for podcast password, auth.php

### DIFF
--- a/PodcastGenerator/auth.php
+++ b/PodcastGenerator/auth.php
@@ -18,7 +18,7 @@ if ($_SESSION['password'] == true) {
     die(_('Already signed in'));
 }
 if (isset($_GET['login'])) {
-    if ($config['podcastPassword'] == $_POST['password']) {
+    if ($config['podcastPassword'] === $_POST['password']) {
         $_SESSION['password'] = true;
         header('Location: index.php');
         die(_('Success'));


### PR DESCRIPTION
There is actually a security vulnerability when we dont use strict identical comparison. Indeed, when we send raw datatype against the form (auth.php), `"podcastPassword" == true`, `"password" == 0` or `"123podcastPassword" == 123` (the two last ones would occur with PHP < 8.0), will always be true, so people could bypass protected podcasts very easily,

Further details:
* https://www.php.net/manual/en/types.comparisons.php
* https://www.php.net/manual/en/language.operators.comparison.php


If you wish, you can play around here: 
* http://sandbox.onlinephpfunctions.com/code/7430822d9f066dda6ebe811d0e39ce4693b73d7e
* http://sandbox.onlinephpfunctions.com/code/908c592e23637f754aec785c735fd88cde5c4f74 (**Select "Run on PHP version", 7.x.x or lower**).
* http://sandbox.onlinephpfunctions.com/code/c3c7f6649d37f8f388282ab2c1a3bede5b43178c  (**Select "Run on PHP version", 7.x.x or lower**).


<img width="848" alt="Screenshot 2021-12-09 at 08 04 53" src="https://user-images.githubusercontent.com/1325411/145324768-3d2e8e69-a8f2-44c3-b6c3-f73a5995d5fd.png">

<img width="627" alt="Screenshot 2021-12-09 at 13 14 49" src="https://user-images.githubusercontent.com/1325411/145325062-5e6380ab-354d-4827-934b-bde39adf8a35.png">

<!-- Please check all checkboxes by putting a 'x' into it. Example: [x] -->

* [x] I am the author of this code or the code is public domain
* [x] I release this code into the public domain


