### PR TITLE
Implement podcast:locked support

### DIFF
--- a/PodcastGenerator/admin/podcast_details.php
+++ b/PodcastGenerator/admin/podcast_details.php
@@ -104,6 +104,20 @@ $custom_tags = getCustomFeedTags();
                 <?= _('No') ?>
             </label>
             <br>
+
+            <?= _('Lock Podcast Feed') ?>: (<?= _('Prevent other platforms from importing your feed') ?>)<br>
+            <label>
+                <input type="radio" name="feed_locked" value="yes" <?= $config['feed_locked'] == 'yes' ? 'checked' : '' ?>>
+                <?= _('Locked'); ?>
+            </label>
+            <label>
+                <input type="radio" name="feed_locked" value="no" <?= $config['feed_locked'] == 'no' ? 'checked' : '' ?>>
+                <?= _('Unlocked') ?>
+            </label>
+            <label>
+                <input type="radio" name="feed_locked" value="" <?= $config['feed_locked'] == '' ? 'checked' : '' ?>>
+                <?= _('Off') ?>
+            </label>
             <br>
 
 <?php if ($config['customtagsenabled'] == 'yes') { ?>

--- a/PodcastGenerator/core/backwards.php
+++ b/PodcastGenerator/core/backwards.php
@@ -121,6 +121,8 @@ function backwards_3_1_to_3_2($absoluteurl)
 
 \$feed_sort = '" . $config['feed_sort'] . "'; // sort method used to order episodes in the feed (by timestamp or by season/episode number)
 
+\$feed_locked = ''; // podcast:locked status ('yes', 'no', '' for off)
+
 \$copyright = '" . $config['copyright'] . "';   // Your copyright notice (e.g CC-BY)
 
 \$feed_encoding = '" . $config['feed_encoding'] . "';

--- a/PodcastGenerator/core/feed_generator.php
+++ b/PodcastGenerator/core/feed_generator.php
@@ -195,6 +195,11 @@ function generateRSS()
         $feedhead .= '		<atom:link href="' . $config['websub_server'] . '" rel="hub" />' . "\n";
     }
 
+    if ($config['feed_locked'] != '') {
+        $feedhead .= '		<podcast:locked owner="' . htmlspecialchars($config['author_email']) . '">'
+            . $config['feed_locked'] . '</podcast:locked>' . "\n";
+    }
+
     $custom_tags = getCustomFeedTags();
     if ($custom_tags != '') {
         foreach (preg_split("/\r\n|\n|\r/", $custom_tags) as $line) {

--- a/PodcastGenerator/setup/createconf.php
+++ b/PodcastGenerator/setup/createconf.php
@@ -110,6 +110,8 @@ function createconf($username, $password)
 
 \$feed_sort = 'timestamp'; // sort method used to order episodes in the feed (by timestamp or by season/episode number)
 
+\$feed_locked = ''; // podcast:locked status ('yes', 'no', '' for off)
+
 \$copyright = 'All rights reserved';   // Your copyright notice (e.g CC-BY)
 
 \$feed_encoding = 'utf-8';


### PR DESCRIPTION
Provides users to enable podcast:locked with a yes or no value, or
disable it so that the tag does not appear at all in the show's feed.
See https://podcastindex.org/namespace/1.0#locked

Closes #369