### PR TITLE
fix(episodes.php): use full path for non-renamed files

### DIFF
--- a/PodcastGenerator/core/episodes.php
+++ b/PodcastGenerator/core/episodes.php
@@ -319,6 +319,9 @@ function indexEpisodes($_config)
             }
             rename($uploadDir . $filename, $new_filename);
             $fname = $new_filename;
+        } else {
+            // We don't need to rename the file, but we do need to get the full path
+            $fname = $uploadDir . $filename;
         }
 
         // Get audio metadata (duration, bitrate etc)


### PR DESCRIPTION
Ensure that `$fname` is the full path to an episode file before getting metadata for the file and episode.

fixes #508