### PR TITLE
Changes calls to filemtime to use lstat so symbolic links work

### DIFF
--- a/PodcastGenerator/admin/episodes_edit.php
+++ b/PodcastGenerator/admin/episodes_edit.php
@@ -285,7 +285,7 @@ if (count($_POST) > 0) {
 
 // Get episode data
 $episode = simplexml_load_file($targetfile_without_ext . '.xml');
-$filemtime = filemtime($targetfile);
+$filemtime = lstat($targetfile)['mtime'];
 
 $coverart = (string) $episode->episode->imgPG;
 if (empty($coverart)) {

--- a/PodcastGenerator/core/episodes.php
+++ b/PodcastGenerator/core/episodes.php
@@ -86,7 +86,7 @@ function getEpisodeFiles($_config, $includeFuture = false)
 
             if (!$includeFuture) {
                 // if file exists in the future, skip
-                $lastModified = filemtime($filePath);
+                $lastModified = lstat($filePath)['mtime'];
                 if ($now < $lastModified) {
                     continue;
                 }
@@ -100,7 +100,7 @@ function getEpisodeFiles($_config, $includeFuture = false)
             array_push($files, [
                 'filename' => $entry,
                 'path' => $filePath,
-                'lastModified' => filemtime($filePath),
+                'lastModified' => lstat($filePath)['mtime'],
                 'data' => simplexml_load_file($dataFile, null, LIBXML_NOCDATA)
             ]);
         }
@@ -116,7 +116,7 @@ function getEpisodeFiles($_config, $includeFuture = false)
 
 function arrayEpisode($item, $episode, $_config)
 {
-    $filemtime = filemtime($_config['absoluteurl'] . $_config['upload_dir'] . $episode);
+    $filemtime = lstat($_config['absoluteurl'] . $_config['upload_dir'] . $episode)['mtime'];
     $append_array = [
         'episode' => [
             'guid' => $item->guid,


### PR DESCRIPTION
I prefer creating symbolic links in my media folder to use the FTP Auto Indexing feature rather than copying my files directly into the media folder. The only difficulty I've had is that episode's publication date doesn't use the modification time of the symbolic link file itself, but instead uses the modification time of the file that is linked to.

This commit changes every call to filemtime($filename) to lstat($filename)['mtime']. The only difference between the two formulations is that lstat references the symbolic link itself, while `filemtime` follows the link.

The reason I prefer using symbolic links in the media file is that I use the same media for several different PodcastGenerator podcasts, but I need to set the publication dates of a particular media file differently for each podcast I include it in.

<!-- Please check all checkboxes by putting a 'x' into it. Example: [x] -->

* [x] I am the author of this code or the code is public domain
* [x] I release this code into the public domain
