### PR TITLE
Close <name> tag for hebrew language

### DIFF
--- a/PodcastGenerator/components/supported_languages/supported_languages.xml
+++ b/PodcastGenerator/components/supported_languages/supported_languages.xml
@@ -26,7 +26,7 @@
 	</language>
 	<language>
 		<code>he_IL</code>
-		<name>עִבְרִית</code>
+		<name>עִבְרִית</name>
 	</language>
 	<language>
 		<code>sv_SE</code>


### PR DESCRIPTION
The name tag for hebrew language should be <name>עִבְרִית</name> instead of <name>עִבְרִית</code> which is incorrect and causes installer to break while selecting language.

* [x ] I am the author of this code or the code is public domain
* [ x] I release this code into the public domain
