### PR TITLE
Fixing HTML/XML escaping for episode title and itunes:author

### DIFF
--- a/PodcastGenerator/core/feed_generator.php
+++ b/PodcastGenerator/core/feed_generator.php
@@ -105,7 +105,7 @@ function generateRssItem($file, $uploadDir, $uploadUrl, $imagesDir, $imagesUrl)
         $item .= $TAB . '<itunes:author>' . htmlspecialchars($file['data']->episode->authorPG->namePG)
             . '</itunes:author>' . $LR;
     } else {
-        $item .= $TAB . '<itunes:author>' . $config['author_name'] . '</itunes:author>' . $LR;
+        $item .= $TAB . '<itunes:author>' . htmlspecialchars($config['author_name']) . '</itunes:author>' . $LR;
     }
 
     if ($file['data']->episode->keywordsPG != "") {

--- a/PodcastGenerator/core/feed_generator.php
+++ b/PodcastGenerator/core/feed_generator.php
@@ -75,7 +75,7 @@ function generateRssItem($file, $uploadDir, $uploadUrl, $imagesDir, $imagesUrl)
 
     $item = '
     <item>' . "\n";
-    $item .= $TAB . '<title>' . $file['data']->episode->titlePG . '</title>' . $LR;
+    $item .= $TAB . '<title>' . htmlspecialchars($file['data']->episode->titlePG) . '</title>' . $LR;
 
     if (!empty($file['data']->episode->episodeNumPG)) {
         $item .= $TAB . '<itunes:episode>' . $file['data']->episode->episodeNumPG . '</itunes:episode>' . $LR;


### PR DESCRIPTION
The generated XML was broken if the site-wide author had `&` or other special characters.

The generated XML was broken if the episode title had `&` or other special characters.

There may be other instances of raw text being improperly escaped, but I haven't checked those yet.

It looks like the description fields (and possibly other fields) will break if it contains `]]>` (which marks the end of the CDATA). Look at: https://stackoverflow.com/q/223652

<!-- Please check all checkboxes by putting a 'x' into it. Example: [x] -->

* [x] I am the author of this code or the code is public domain
* [x] I release this code into the public domain

---

Amusing fact: if accepted, looks like these changes will be around the 1000th commit in this repository.
![999 commits](https://user-images.githubusercontent.com/121676/165951508-fabc3747-cbf7-43e2-85ed-087e9ddad078.png)
