### PR TITLE
Let authorname and authoremail be optional in episodes_edit.php

### DIFF
--- a/PodcastGenerator/admin/episodes_edit.php
+++ b/PodcastGenerator/admin/episodes_edit.php
@@ -431,7 +431,7 @@ $selected_cats = array(
                         <br>
                     </div>
                     <div class="form-group">
-                        <label for="authorname" class="req"><?= _('Author') ?>:</label><br>
+                        <label for="authorname"><?= _('Author') ?>:</label><br>
                         <input type="text" id="authorname" name="authorname" class="form-control"
                                placeholder="Author Name"
                                value="<?= htmlspecialchars($episode->episode->authorPG->namePG) ?>">

--- a/PodcastGenerator/admin/episodes_edit.php
+++ b/PodcastGenerator/admin/episodes_edit.php
@@ -47,9 +47,7 @@ if (count($_POST) > 0) {
         $_POST['shortdesc'],
         $_POST['date'],
         $_POST['time'],
-        $_POST['explicit'],
-        $_POST['authorname'],
-        $_POST['authoremail']
+        $_POST['explicit']
     ];
     // Check if fields are missing
     for ($i = 0; $i < count($req_fields); $i++) {
@@ -71,7 +69,7 @@ if (count($_POST) > 0) {
     }
 
     // Check author e-mail
-    if (isset($_POST['authoremail'])) {
+    if (!empty($_POST['authoremail'])) {
         if (!filter_var($_POST['authoremail'], FILTER_VALIDATE_EMAIL)) {
             $error = _('Invalid Author E-Mail provided');
             goto error;

--- a/PodcastGenerator/admin/episodes_upload.php
+++ b/PodcastGenerator/admin/episodes_upload.php
@@ -435,7 +435,7 @@ if (!isset($customTags)) {
                         <br>
                     </div>
                     <div class="form-group">
-                    <label for="authorname" class="req"><?= _('Author') ?>:</label><br>
+                    <label for="authorname"><?= _('Author') ?>:</label><br>
                         <input type="text" id="authorname" name="authorname" class="form-control"
                                placeholder="<?= htmlspecialchars($config["author_name"]) ?>">
                         <br>


### PR DESCRIPTION
There is a lot of duplicate code between `episodes_edit.php` and `episodes_upload.php`. There are some discrepancies. For example, I could leave the author name/e-mail empty when uploading a new episode; but I can't save the changes to an episode if those same fields are empty.

This commit makes the list of required fields more consistent between upload/edit actions.

<!-- Please check all checkboxes by putting a 'x' into it. Example: [x] -->

* [x] I am the author of this code or the code is public domain
* [x] I release this code into the public domain
