### PR TITLE
Fix 'undefined array key' error in getmime function

### DIFF
--- a/PodcastGenerator/admin/episodes_ftp_feature.php
+++ b/PodcastGenerator/admin/episodes_ftp_feature.php
@@ -46,7 +46,7 @@ if (isset($_GET['start'])) {
             <form action="episodes_ftp_feature.php?start=1" method="POST">
             <input type="hidden" name="token" value="<?= $_SESSION['token']  ?>">
             <input class="btn btn-success" type="submit" value="<?= _('Begin') ?>">
-            </form>';
+            </form>
         <?php } ?>
         <?php if (isset($success)) { ?>
             <p><?= htmlspecialchars($success) ?></p>

--- a/PodcastGenerator/core/misc/functions.php
+++ b/PodcastGenerator/core/misc/functions.php
@@ -22,7 +22,7 @@ function getmime($filename)
     // Analyze file to determine mime type
     $getID3 = new getID3();
     $fileinfo = $getID3->analyze($filename);
-    return $fileinfo["mime_type"];
+    return isset($fileinfo["mime_type"]) ? $fileinfo["mime_type"] : null;
 }
 
 function checkLogin($username, $password_plain)


### PR DESCRIPTION
Was getting an error printed above the header every time when processing FTP uploads and traced it here. 

Also, removed some extra characters (';) showing on the screen below the 'Begin' button.

<!-- Please check all checkboxes by putting a 'x' into it. Example: [x] -->

* [x] I am the author of this code or the code is public domain
* [x] I release this code into the public domain
