### PR TITLE
fix(theme): force episode downloads

### DIFF
--- a/PodcastGenerator/themes/default/listepisodes.php
+++ b/PodcastGenerator/themes/default/listepisodes.php
@@ -58,7 +58,7 @@ for ($i = 0; $i < count($episode_chunk); $i++) {
                 <?php } ?>
 
                 <a class="btn btn-outline-primary btn-sm" href="<?= $config['indexfile'] . '?' . $link . '=' . $item[$i]["episode"]["filename"] ?>"><?= $more ?></a>
-                <a class="btn btn-outline-success btn-sm" href="media/<?= $item[$i]["episode"]["filename"] ?>"><?= $download ?></a><br>
+                <a class="btn btn-outline-success btn-sm" href="media/<?= $item[$i]["episode"]["filename"] ?>" download><?= $download ?></a><br>
 
                 <?php if ($type != 'invalid') { ?>
                     <small style="font-size:65%" class="text-muted">

--- a/PodcastGenerator/themes/default/singleepisode.php
+++ b/PodcastGenerator/themes/default/singleepisode.php
@@ -68,7 +68,7 @@ if ($config['categoriesenabled'] == 'yes') {
                     <?php if (isset($_SESSION["username"])) { ?>
                         <a class="btn btn-dark btn-sm" href="admin/episodes_edit.php?name=<?= $episodes[$i]["episode"]["filename"] ?>"><?= $editdelete ?></a>
                     <?php } ?>
-                    <a class="btn btn-outline-success btn-sm" href="media/<?= $correctepisode["episode"]["filename"] ?>"><?= $download ?></a><br>
+                    <a class="btn btn-outline-success btn-sm" href="media/<?= $correctepisode["episode"]["filename"] ?>" download><?= $download ?></a><br>
 
                     <?php if ($type != 'invalid') { ?>
                         <small style="font-size:65%" class="text-muted">


### PR DESCRIPTION
Add the `download` attribute to the anchor tags for the download buttons in the default theme. This should force browsers into downloading episode media instead of opening it in the browser.

Fixes #714