### PR TITLE
Theme paginator

### DIFF
--- a/PodcastGenerator/themes/default/functions.php
+++ b/PodcastGenerator/themes/default/functions.php
@@ -1,0 +1,64 @@
+<?php
+
+function _pagination_build_item(?int $page, string $url)
+{
+    if ($page == null) {
+        return ['l' => '...', 'h' => null];
+    }
+    return ['l' => $page, 'h' => str_replace('%page%', $page, $url)];
+}
+
+function _pagination_render(array $items, int $currentPage)
+{
+    ?><ul class="pagination justify-content-center">
+        <?php foreach ($items as $i) { ?>
+            <li class="page-item <?= ($i['l'] == $currentPage ? 'active' : '') ?> ">
+                <?php if ($i['l'] == $currentPage) { ?>
+                    <span class="page-link">
+                        <?= $currentPage ?>
+                        <span class="sr-only"><?= _('(current)') ?></span>
+                    </span>
+                <?php } elseif (empty($i['h'])) { ?>
+                    <span class="page-link"><?= $i['l'] ?></span>
+                <?php } else { ?>
+                    <a class="page-link" href="<?= $i['h'] ?>"><?= $i['l'] ?></a>
+                <?php } ?>
+            </li> 
+        <?php } ?>
+    </ul><?php
+}
+
+function pagination(string $url, int $pageCount, int $currentPage, int $adjacents = 2)
+{
+    $spans = [
+        [1, 1 + $adjacents],
+        [$currentPage - $adjacents, $currentPage + $adjacents],
+        [$pageCount - $adjacents, $pageCount]
+    ];
+
+    // merge spans if they overlap or 'touch'
+    $spans2 = [$spans[0]];
+    $spans2idx = 0;
+    for ($i = 1; $i < count($spans); $i++) {
+        if ($spans2[$spans2idx][1] >= $spans[$i][0] - 1) {
+            $spans2[$spans2idx][1] = $spans[$i][1];
+        } else {
+            $spans2[] = $spans[$i];
+            $spans2idx++;
+        }
+    }
+
+    // build items list
+    $items = [];
+    foreach ($spans2 as $span) {
+        if ($spans2[0] != $span) {
+            $items[] = _pagination_build_item(null, '');
+        }
+        for ($i = $span[0]; $i <= $span[1]; $i++) {
+            $items[] = _pagination_build_item($i, $url);
+        }
+    }
+
+    // render
+    _pagination_render($items, $currentPage);
+}

--- a/PodcastGenerator/themes/default/index.php
+++ b/PodcastGenerator/themes/default/index.php
@@ -1,3 +1,6 @@
+<?php
+require_once(__DIR__ . '/functions.php');
+?>
 <!DOCTYPE html>
 <html>
 
@@ -94,12 +97,8 @@
             ?>
         </div>
         <?php if (!isset($_GET[$link]) && !isset($no_episodes) && count($episodes) > intval($config['episodeperpage'])) { ?>
-            <nav>
-                <ul class="pagination">
-                    <?php for ($j = 0; $j < count($splitted_episodes); $j++) { ?>
-                        <li class="page-item"><a class="page-link" href="<?= $config['indexfile'] . '?page=' . ($j + 1) ?>"><?= $j + 1 ?></a></li>
-                    <?php } ?>
-                </ul>
+            <nav aria-label="<?= _('Page navigation') ?>">
+                <?php pagination($config['indexfile'] . '?page=%page%', count($splitted_episodes) - 1, $_GET['page'] ?? 1); ?>
             </nav>
         <?php } ?>
         <hr>

--- a/PodcastGenerator/themes/default/navbar.php
+++ b/PodcastGenerator/themes/default/navbar.php
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark" aria-label="<?= _('Site navigation') ?>">
     <div class="container">
         <a class="navbar-brand" href="<?= $config['indexfile']; ?>"><?= $config["podcast_title"] ?></a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
Provides a nicer paginator for list pages using the default theme. This one limits itself to how many pages are actually linked at any given time, rather than listing all of them, so for shows with a lot of episodes it should not overflow onto multiple lines.

Fixes #510.